### PR TITLE
Fix test initialization for encoder and block

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -6,12 +6,13 @@ from models.prediction_blocks import Level1PredictionBlock, Level2PredictionBloc
 
 class TestEncoders(unittest.TestCase):
     def test_level1_encoder(self):
-        vocab_size = 100
+        cpt_vocab_size = 100
+        icd_vocab_size = 80
         embedding_dim = 50
-        encoder = Level1Encoder(vocab_size, embedding_dim, token_type='cpt')
-        tokens = torch.randint(0, vocab_size, (2, 10))  # [batch_size, num_tokens]
-        output = encoder(tokens, 'cpt')
-        self.assertEqual(output.shape, (2, embedding_dim * 3))
+        encoder = Level1Encoder(cpt_vocab_size, icd_vocab_size, embedding_dim)
+        tokens = torch.randint(0, cpt_vocab_size, (2, 3, 10))  # [batch_size, num_claims, num_tokens]
+        output, mask = encoder(tokens, 'cpt')
+        self.assertEqual(output.shape, (2, 3, embedding_dim * 3))
 
     def test_level2_encoder(self):
         cpt_vocab_size = 100
@@ -19,19 +20,21 @@ class TestEncoders(unittest.TestCase):
         ttnc_vocab_size = 50
         embedding_dim = 50
         encoder = Level2Encoder(cpt_vocab_size, icd_vocab_size, ttnc_vocab_size, embedding_dim)
-        cpt_tokens = torch.randint(0, cpt_vocab_size, (2, 10))
-        icd_tokens = torch.randint(0, icd_vocab_size, (2, 10))
-        ttnc_tokens = torch.randint(0, ttnc_vocab_size, (2, 10))
+        cpt_tokens = torch.randint(0, cpt_vocab_size, (2, 4, 10))
+        icd_tokens = torch.randint(0, icd_vocab_size, (2, 4, 8))
+        ttnc_tokens = torch.randint(0, ttnc_vocab_size, (2, 4))
         output = encoder(cpt_tokens, icd_tokens, ttnc_tokens)
-        self.assertEqual(output.shape, (2, embedding_dim))
+        self.assertEqual(output.shape, (2, 4, embedding_dim))
 
 class TestPredictionBlocks(unittest.TestCase):
     def test_level2_prediction_block(self):
         embed_dim = 100
         output_dim = 50
+        cpt_vocab_size = 200
+        icd_vocab_size = 150
         ttnc_vocab_size = 50
         max_seq_length = 100
-        block = Level2PredictionBlock(embed_dim, output_dim, ttnc_vocab_size, max_seq_length)
+        block = Level2PredictionBlock(embed_dim, output_dim, cpt_vocab_size, icd_vocab_size, ttnc_vocab_size, max_seq_length)
         context_embeddings = torch.randn(2, 10, embed_dim)
         ttnc_tokens = torch.randint(0, ttnc_vocab_size, (2, 10))
         patient_representation, prediction = block(context_embeddings, ttnc_tokens)


### PR DESCRIPTION
## Summary
- update tests for new `Level1Encoder` and `Level2PredictionBlock` parameters
- use vocab sizes for dummy tensors

## Testing
- `python -m unittest -v` *(fails: ModuleNotFoundError: No module named 'torch')*