### PR TITLE
Add sparse autoencoder training

### DIFF
--- a/models/hierarchical_model.py
+++ b/models/hierarchical_model.py
@@ -7,6 +7,7 @@ import pytorch_lightning as pl
 import numpy as np
 from models.encoders import Level1Encoder, Level2Encoder
 from models.prediction_blocks import Level1PredictionBlock, Level2PredictionBlock, LogitsGenerator
+from models.sparse_autoencoder import SparseAutoencoder
 from utils.metrics import calculate_rmse
 from utils.tensor_utils import calculate_entropy
 from sklearn.model_selection import KFold
@@ -189,6 +190,7 @@ class HierarchicalClaimsModel(pl.LightningModule):
         self.use_level1 = config.use_level1
         self.use_zero_target_mask = config.use_zero_target_mask
         self.use_token_prediction_head = config.use_token_prediction_head
+        self.use_sparse_autoencoder = config.use_sparse_autoencoder
         self.cpt_vocab_size=config.cpt_vocab_size,
         self.icd_vocab_size=config.icd_vocab_size,
 
@@ -265,6 +267,13 @@ class HierarchicalClaimsModel(pl.LightningModule):
             icd_vocab_size=config.icd_vocab_size,
         )
 
+        if self.use_sparse_autoencoder:
+            self.sparse_autoencoder = SparseAutoencoder(
+                input_dim=config.embedding_dim,
+                hidden_dim=config.sae_hidden_dim,
+                k=config.sae_k,
+            )
+
         self.lr = config.lr
         self.loss_fn = nn.MSELoss()
         # Adjust the size of log_vars since we're removing the adversarial component
@@ -273,8 +282,9 @@ class HierarchicalClaimsModel(pl.LightningModule):
             'vicreg_lvl2': nn.Parameter(torch.zeros(1)),
             'task': nn.Parameter(torch.zeros(1)),
             'token_pred': nn.Parameter(torch.zeros(1)),
+            'sae': nn.Parameter(torch.zeros(1)),
             #'adversarial': nn.Parameter(torch.zeros(1)),
-        }) 
+        })
 
         if self.use_predictor_head:
             self.non_linear_predictor = nn.Sequential(
@@ -394,12 +404,13 @@ class HierarchicalClaimsModel(pl.LightningModule):
 
         return vicreg_loss, var_loss, inv_loss
 
-    def calculate_total_loss(self, vicreg_loss_lvl1, vicreg_loss_lvl2, task_loss, lvl2_weight, token_pred_loss):
+    def calculate_total_loss(self, vicreg_loss_lvl1, vicreg_loss_lvl2, task_loss, lvl2_weight, token_pred_loss, sae_loss=0):
         # Conceptually - https://arxiv.org/pdf/1705.07115
         log_var_denom = 2
         log_var_denom += 1 if self.use_level1 else 0
         log_var_denom += 1 if self.use_predictor_head else 0
         log_var_denom += 1 if self.use_token_prediction_head else 0
+        log_var_denom += 1 if self.use_sparse_autoencoder else 0
 
 
         clamped_log_vars = {k: torch.clamp(v, min=-10, max=10) for k, v in self.log_vars.items()}
@@ -434,6 +445,13 @@ class HierarchicalClaimsModel(pl.LightningModule):
             total_loss = total_loss + weighted_token_loss
             total_precision = total_precision + precision_token
             total_log_var = total_log_var + clamped_log_vars['token_pred']
+
+        if self.use_sparse_autoencoder:
+            precision_sae = torch.exp(clamped_log_vars['sae'])
+            weighted_sae_loss = sae_loss * precision_sae
+            total_loss = total_loss + weighted_sae_loss
+            total_precision = total_precision + precision_sae
+            total_log_var = total_log_var + clamped_log_vars['sae']
 
             # precision_adv = torch.exp(clamped_log_vars['adversarial'])
             # total_loss += adversarial_loss * precision_adv
@@ -670,13 +688,19 @@ class HierarchicalClaimsModel(pl.LightningModule):
             # adversarial_loss = self.adversarial_loss(fake_preds_for_generator, real_labels_for_generator)
 
 
+        sae_loss = 0
+        if self.use_sparse_autoencoder:
+            recon = self.sparse_autoencoder(patient_representation)
+            sae_loss = F.mse_loss(recon, patient_representation)
+
         # Compute total loss
         total_loss, task_loss = self.calculate_total_loss(
-            vicreg_loss_lvl1, 
-            vicreg_loss_lvl2, 
-            task_loss, 
+            vicreg_loss_lvl1,
+            vicreg_loss_lvl2,
+            task_loss,
             lvl2_weight=self.level_2_weight,
             token_pred_loss=token_pred_loss,
+            sae_loss=sae_loss,
             #adversarial_loss=adversarial_loss
         )
 
@@ -693,6 +717,7 @@ class HierarchicalClaimsModel(pl.LightningModule):
             'patient_representation': patient_representation,
             'task_loss': task_loss,
             'token_pred_loss': token_pred_loss,
+            'sae_loss': sae_loss,
             'cpt_logits': cpt_logits if self.use_token_prediction_head else None,
             'icd_logits': icd_logits if self.use_token_prediction_head else None,
             'ttnc_logits': ttnc_logits if self.use_token_prediction_head else None,
@@ -784,7 +809,8 @@ class HierarchicalClaimsModel(pl.LightningModule):
             vicreg_loss_lvl2=outputs['vicreg_loss_lvl2'],
             task_loss=outputs['task_loss'],
             lvl2_weight=self.level_2_weight,
-            token_pred_loss=outputs['token_pred_loss']
+            token_pred_loss=outputs['token_pred_loss'],
+            sae_loss=outputs['sae_loss']
         )
 
         # --- Logging ---
@@ -793,6 +819,8 @@ class HierarchicalClaimsModel(pl.LightningModule):
         # Preserve existing logging
         if self.use_token_prediction_head:
             self.log('token_pred_loss', outputs['token_pred_loss'], on_step=False, on_epoch=True, prog_bar=True, logger=True)
+        if self.use_sparse_autoencoder:
+            self.log('sae_loss', outputs['sae_loss'], on_step=False, on_epoch=True, prog_bar=True, logger=True)
         
         if self.use_level1:
             self.log('Iloss1', outputs['inv_loss_lvl1'], on_step=False, on_epoch=True, prog_bar=True, logger=True)
@@ -903,6 +931,8 @@ class HierarchicalClaimsModel(pl.LightningModule):
             gen_params.extend(self.prediction_block_lvl1.parameters())
         gen_params.extend(self.context_encoder_lvl2.parameters())
         gen_params.extend(self.prediction_block_lvl2.parameters())
+        if self.use_sparse_autoencoder:
+            gen_params.extend(self.sparse_autoencoder.parameters())
         gen_params.extend(self.log_vars.parameters())  # Add individual parameters from ParameterDict
         gen_params.extend(self.logits_generator.parameters())
         if self.use_predictor_head:

--- a/models/sparse_autoencoder.py
+++ b/models/sparse_autoencoder.py
@@ -1,0 +1,33 @@
+import torch
+import torch.nn as nn
+
+class TopKActivation(nn.Module):
+    """Applies a Top-K sparsity operation to the input."""
+
+    def __init__(self, k: int):
+        super().__init__()
+        self.k = k
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        if self.k >= x.size(1):
+            return x
+        # Determine the threshold for top-k (by absolute value)
+        topk_values = torch.topk(x.abs(), self.k, dim=1).values
+        kth_vals = topk_values[:, -1].unsqueeze(1)
+        mask = x.abs() >= kth_vals
+        return x * mask.float()
+
+
+class SparseAutoencoder(nn.Module):
+    """Simple sparse autoencoder with Top-K activation."""
+
+    def __init__(self, input_dim: int, hidden_dim: int, k: int):
+        super().__init__()
+        self.encoder = nn.Linear(input_dim, hidden_dim)
+        self.activation = TopKActivation(k)
+        self.decoder = nn.Linear(hidden_dim, input_dim)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        hidden = self.encoder(x)
+        hidden = self.activation(hidden)
+        return self.decoder(hidden)

--- a/scripts/train_sparse_autoencoder.py
+++ b/scripts/train_sparse_autoencoder.py
@@ -1,0 +1,71 @@
+import torch
+from torch.utils.data import DataLoader, TensorDataset
+from tqdm import tqdm
+
+from utils.config import Config
+from models.data_prep import prepare_data
+from models.hierarchical_model import HierarchicalClaimsModel
+from models.sparse_autoencoder import SparseAutoencoder
+
+
+def extract_embeddings(model, dataloader, device):
+    """Run the hierarchical model to obtain patient representations."""
+    model.eval()
+    embeddings = []
+    with torch.no_grad():
+        for batch in tqdm(dataloader, desc="Extracting embeddings"):
+            cpt_tensor, icd_tensor, ttnc_tensor, _ = batch
+            cpt_tensor = cpt_tensor.to(device)
+            icd_tensor = icd_tensor.to(device)
+            ttnc_tensor = ttnc_tensor.to(device)
+            outputs = model(cpt_tensor=cpt_tensor, icd_tensor=icd_tensor, ttnc_tensor=ttnc_tensor)
+            embeddings.append(outputs["patient_representation"].cpu())
+    return torch.cat(embeddings, dim=0)
+
+
+def train_autoencoder(embeddings, hidden_dim=64, k=32, epochs=10, lr=1e-3, device="cpu"):
+    dataset = TensorDataset(embeddings)
+    dataloader = DataLoader(dataset, batch_size=256, shuffle=True)
+    sae = SparseAutoencoder(embeddings.size(1), hidden_dim, k).to(device)
+    optimizer = torch.optim.Adam(sae.parameters(), lr=lr)
+    criterion = torch.nn.MSELoss()
+    sae.train()
+    for epoch in range(epochs):
+        running_loss = 0.0
+        for (batch,) in dataloader:
+            batch = batch.to(device)
+            optimizer.zero_grad()
+            recon = sae(batch)
+            loss = criterion(recon, batch)
+            loss.backward()
+            optimizer.step()
+            running_loss += loss.item() * batch.size(0)
+        avg_loss = running_loss / len(dataset)
+        print(f"Epoch {epoch+1}/{epochs} - Loss: {avg_loss:.4f}")
+    return sae
+
+
+def main():
+    config = Config()
+    # Load data
+    _, train_dataloader, _, _, config, _ = prepare_data(config)
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    # Load pretrained hierarchical model
+    model = HierarchicalClaimsModel(config)
+    model.load_state_dict(torch.load("hierarchical_model.pt", map_location=device))
+    model = model.to(device)
+
+    # Extract embeddings
+    embeddings = extract_embeddings(model, train_dataloader, device)
+
+    # Train SAE
+    sae = train_autoencoder(embeddings, hidden_dim=config.embedding_dim, k=32, epochs=20, device=device)
+
+    # Save weights
+    torch.save(sae.state_dict(), "sparse_autoencoder.pt")
+    print("Saved sparse autoencoder weights to sparse_autoencoder.pt")
+
+
+if __name__ == "__main__":
+    main()

--- a/utils/config.py
+++ b/utils/config.py
@@ -48,3 +48,6 @@ class Config:
     use_zero_target_mask = True # Zeros are bad data in my DS - used with use_na_targets
     use_token_prediction_head = True
     use_generative_save = True
+    use_sparse_autoencoder: bool = True
+    sae_hidden_dim: int = 128
+    sae_k: int = 32


### PR DESCRIPTION
## Summary
- introduce `SparseAutoencoder` with Top-K activation
- add script to extract embeddings from pre-trained `HierarchicalClaimsModel` and train the sparse autoencoder
- integrate sparse autoencoder in `HierarchicalClaimsModel` for joint training

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*