### PR TITLE
Add SAE gating fusion option

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,11 @@ python train_sparse_autoencoder.py --config path/to/sae_config.yaml
 ```
 
 To fuse the SAE representation with the JEPA encoders set a gating option in the
-configuration.  Add a boolean field such as `use_gated_fusion = True` in your
-`Config` dataclass and enable it when training JEPA.  When active, the model
-learns a small gating network that blends the SAE output with the contextual
-embedding from JEPA.  This improves stability and allows the pretrained SAE to
-guide the hierarchical encoders during early training.
+configuration.  Set `use_gated_fusion = True` in your `Config` dataclass and the
+model will instantiate a small gating network that blends the SAE output with
+the contextual embedding from JEPA.  This mechanism is now implemented and
+improves training stability by letting the pretrained SAE guide the hierarchical
+encoders during early epochs.
 
 # Future state
 I'm considering adding a GAN back to the public version.

--- a/models/hierarchical_model.py
+++ b/models/hierarchical_model.py
@@ -191,6 +191,7 @@ class HierarchicalClaimsModel(pl.LightningModule):
         self.use_zero_target_mask = config.use_zero_target_mask
         self.use_token_prediction_head = config.use_token_prediction_head
         self.use_sparse_autoencoder = config.use_sparse_autoencoder
+        self.use_gated_fusion = config.use_gated_fusion
         self.cpt_vocab_size=config.cpt_vocab_size,
         self.icd_vocab_size=config.icd_vocab_size,
 
@@ -273,6 +274,12 @@ class HierarchicalClaimsModel(pl.LightningModule):
                 hidden_dim=config.sae_hidden_dim,
                 k=config.sae_k,
             )
+            if self.use_gated_fusion:
+                self.sae_to_embed = nn.Linear(config.sae_hidden_dim, config.embedding_dim)
+                self.gating_network = nn.Sequential(
+                    nn.Linear(config.embedding_dim + config.embedding_dim, config.embedding_dim),
+                    nn.Sigmoid()
+                )
 
         self.lr = config.lr
         self.loss_fn = nn.MSELoss()
@@ -692,6 +699,12 @@ class HierarchicalClaimsModel(pl.LightningModule):
         if self.use_sparse_autoencoder:
             recon = self.sparse_autoencoder(patient_representation)
             sae_loss = F.mse_loss(recon, patient_representation)
+            if self.use_gated_fusion:
+                sae_encoded = self.sparse_autoencoder.encoder(patient_representation)
+                sae_embed = self.sae_to_embed(sae_encoded)
+                gate_input = torch.cat([patient_representation, sae_embed], dim=-1)
+                gate = self.gating_network(gate_input)
+                patient_representation = gate * sae_embed + (1 - gate) * patient_representation
 
         # Compute total loss
         total_loss, task_loss = self.calculate_total_loss(

--- a/utils/config.py
+++ b/utils/config.py
@@ -49,5 +49,6 @@ class Config:
     use_token_prediction_head = True
     use_generative_save = True
     use_sparse_autoencoder: bool = True
+    use_gated_fusion: bool = False
     sae_hidden_dim: int = 128
     sae_k: int = 32


### PR DESCRIPTION
## Summary
- introduce `use_gated_fusion` flag in `Config`
- build gating network when SAE and fusion are enabled
- fuse SAE embedding with JEPA representation during forward pass
- document feature in README

## Testing
- `python tests/test_models.py` *(fails: ModuleNotFoundError: No module named 'torch')*