### PR TITLE
Add setup.py for editable install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,17 @@
+from setuptools import setup, find_packages
+
+setup(
+    name='jepaforclaims',
+    version='0.1.0',
+    packages=find_packages(),
+    install_requires=[
+        'torch',
+        'pytorch-lightning',
+        'pandas',
+        'scikit-learn',
+        'numpy',
+        'matplotlib',
+        'seaborn',
+        'tqdm',
+    ],
+)


### PR DESCRIPTION
## Summary
- add simple `setup.py` so the project can be installed in editable mode

## Testing
- `python -m unittest discover -s tests` *(fails: ModuleNotFoundError)*
- `pip install -e .` *(fails: could not connect to PyPI)*