### PR TITLE
Add pkl support to data loader

### DIFF
--- a/data/data_loader.py
+++ b/data/data_loader.py
@@ -2,10 +2,14 @@ import pandas as pd
 
 
 def _read_file(path: str) -> pd.DataFrame:
-    """Read a dataframe from a parquet or pickle file based on extension."""
+    """Read a dataframe from a parquet or pickle file based on extension.
+
+    Supports ``.parquet`` as well as pickle extensions ``.pckl``, ``.pickle``
+    and ``.pkl``.
+    """
     if path.endswith('.parquet'):
         return pd.read_parquet(path)
-    if path.endswith('.pckl') or path.endswith('.pickle'):
+    if path.endswith('.pckl') or path.endswith('.pickle') or path.endswith('.pkl'):
         return pd.read_pickle(path)
     # fallback to csv
     return pd.read_csv(path)

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -22,6 +22,20 @@ class TestDataLoader(unittest.TestCase):
             self.assertTrue(loaded_train.equals(train_df))
             self.assertTrue(loaded_test.equals(test_df))
 
+    def test_load_data_pkl_extension(self):
+        """Ensure loading works with ``.pkl`` files."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            train_path = os.path.join(tmpdir, "train.pkl")
+            test_path = os.path.join(tmpdir, "test.pkl")
+            train_df = pd.DataFrame({"a": [9, 10]})
+            test_df = pd.DataFrame({"b": [11, 12]})
+            train_df.to_pickle(train_path)
+            test_df.to_pickle(test_path)
+
+            loaded_train, loaded_test = load_data(train_path, test_path)
+            self.assertTrue(loaded_train.equals(train_df))
+            self.assertTrue(loaded_test.equals(test_df))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- support `.pkl` data files in `_read_file`
- document supported extensions
- test loading of `.pkl` files

## Testing
- `python -m unittest` *(fails: ModuleNotFoundError: No module named 'pandas')*