### PR TITLE
Add optional pooled patient representation

### DIFF
--- a/jepa_models/hierarchical_model.py
+++ b/jepa_models/hierarchical_model.py
@@ -268,18 +268,19 @@ class HierarchicalClaimsModel(pl.LightningModule):
             rnn_type=config.rnn_type,
             cpt_vocab_size=config.cpt_vocab_size,
             icd_vocab_size=config.icd_vocab_size,
+            use_context_pooled_patient_representation=config.use_context_pooled_patient_representation,
         )
 
         if self.use_sparse_autoencoder:
             self.sparse_autoencoder = SparseAutoencoder(
-                input_dim=config.embedding_dim,
+                input_dim=config.patient_representation_dim,
                 hidden_dim=config.sae_hidden_dim,
                 k=config.sae_k,
             )
             if self.use_gated_fusion:
                 self.sae_to_embed = nn.Linear(config.sae_hidden_dim, config.embedding_dim)
                 self.gating_network = nn.Sequential(
-                    nn.Linear(config.embedding_dim * 2, config.gating_hidden_dim),
+                    nn.Linear(config.patient_representation_dim + config.embedding_dim, config.gating_hidden_dim),
                     nn.ReLU(),
                     nn.Linear(config.gating_hidden_dim, config.embedding_dim),
                     nn.Sigmoid()

--- a/jepa_models/prediction_blocks.py
+++ b/jepa_models/prediction_blocks.py
@@ -93,16 +93,18 @@ class Level2PredictionBlock(nn.Module):
             Useful downstream as input for any patient level predictions.
         context_output (Tensor): The output predictions, shape [batch_size, output_dim].
     """
-    def __init__(self, embed_dim, output_dim, cpt_vocab_size, icd_vocab_size, 
+    def __init__(self, embed_dim, output_dim, cpt_vocab_size, icd_vocab_size,
                  ttnc_vocab_size, max_seq_length, padding_idx=0,
-                 num_layers=4, num_heads=4, ff_hidden_dim=1024, dropout=0.2, 
-                 rnn_type='transformer'):
+                 num_layers=4, num_heads=4, ff_hidden_dim=1024, dropout=0.2,
+                 rnn_type='transformer',
+                 use_context_pooled_patient_representation: bool = False):
         super(Level2PredictionBlock, self).__init__()
 
         self.padding_idx = padding_idx
         # Positional Embedding Layer
         self.position_embedding = nn.Embedding(max_seq_length, embed_dim)
         self.rnn_type = rnn_type
+        self.use_context_pooled_patient_representation = use_context_pooled_patient_representation
 
         # TTNC Embedding Layer
         self.ttnc_embedding = nn.Embedding(ttnc_vocab_size, embed_dim, padding_idx=padding_idx)
@@ -241,8 +243,11 @@ class Level2PredictionBlock(nn.Module):
         # Final predictions
         context_output = self.fc(context_pooled)
 
-        # Here we're simply choosing one of the pooled representations
-        patient_representation = self.dropout(context_mean_pool)
+        # Select the patient representation based on configuration
+        if self.use_context_pooled_patient_representation:
+            patient_representation = self.dropout(context_pooled)
+        else:
+            patient_representation = self.dropout(context_mean_pool)
 
         return patient_representation, context_output
     

--- a/jepa_utils/config.py
+++ b/jepa_utils/config.py
@@ -1,5 +1,5 @@
 # utils/config.py
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 @dataclass
 class Config:
@@ -53,3 +53,10 @@ class Config:
     sae_hidden_dim: int = 128
     sae_k: int = 4
     gating_hidden_dim: int = 128
+    use_context_pooled_patient_representation: bool = False
+    patient_representation_dim: int = field(init=False)
+
+    def __post_init__(self):
+        self.patient_representation_dim = self.embedding_dim * (
+            2 if self.use_context_pooled_patient_representation else 1
+        )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -41,5 +41,27 @@ class TestPredictionBlocks(unittest.TestCase):
         self.assertEqual(patient_representation.shape, (2, embed_dim))
         self.assertEqual(prediction.shape, (2, output_dim))
 
+    def test_level2_prediction_block_context_pooled(self):
+        embed_dim = 100
+        output_dim = 50
+        cpt_vocab_size = 200
+        icd_vocab_size = 150
+        ttnc_vocab_size = 50
+        max_seq_length = 100
+        block = Level2PredictionBlock(
+            embed_dim,
+            output_dim,
+            cpt_vocab_size,
+            icd_vocab_size,
+            ttnc_vocab_size,
+            max_seq_length,
+            use_context_pooled_patient_representation=True,
+        )
+        context_embeddings = torch.randn(2, 10, embed_dim)
+        ttnc_tokens = torch.randint(0, ttnc_vocab_size, (2, 10))
+        patient_representation, prediction = block(context_embeddings, ttnc_tokens)
+        self.assertEqual(patient_representation.shape, (2, embed_dim * 2))
+        self.assertEqual(prediction.shape, (2, output_dim))
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- support config option to derive patient representation from mean+max context pooling
- adjust prediction block and hierarchical model to use this config
- adapt sparse autoencoder and gating network to variable patient representation size
- cover new behavior with tests

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: command not found)*