### PR TITLE
Fix gated fusion dimension mismatch

### DIFF
--- a/jepa_models/encoders.py
+++ b/jepa_models/encoders.py
@@ -113,10 +113,12 @@ class Level2Encoder(nn.Module):
         self.aggregate_attention_norm = nn.LayerNorm(embedding_dim)
         self.component_attention_norm = nn.LayerNorm(embedding_dim)
         self.rescale_factor = nn.Parameter(torch.ones(1) * 0.5)
-        
-        self.cpt_rarity_scores = cpt_rarity_scores if cpt_rarity_scores is not None else {}
-        self.icd_rarity_scores = icd_rarity_scores if icd_rarity_scores is not None else {}
-        self.ttnc_rarity_scores = ttnc_rarity_scores if ttnc_rarity_scores is not None else {}
+
+        # Rarity scores are optional tensors. Avoid assigning empty dictionaries
+        # which cannot be moved to a device.
+        self.cpt_rarity_scores = cpt_rarity_scores
+        self.icd_rarity_scores = icd_rarity_scores
+        self.ttnc_rarity_scores = ttnc_rarity_scores
 
         self.cpt_embedding = nn.Embedding(cpt_vocab_size, embedding_dim, padding_idx=padding_idx)
         self.icd_embedding = nn.Embedding(icd_vocab_size, embedding_dim, padding_idx=padding_idx)
@@ -320,9 +322,9 @@ class Level2Encoder(nn.Module):
         icd_padding_mask = icd_tokens != self.icd_embedding.padding_idx
         ttnc_padding_mask = ttnc_tokens != self.ttnc_embedding.padding_idx
 
-        if self.use_token_rarity and self.cpt_rarity_scores is not None:
+        if self.use_token_rarity and isinstance(self.cpt_rarity_scores, torch.Tensor):
             self.cpt_rarity_scores = self.cpt_rarity_scores.to(device)
-        if self.use_token_rarity and self.icd_rarity_scores is not None:
+        if self.use_token_rarity and isinstance(self.icd_rarity_scores, torch.Tensor):
             self.icd_rarity_scores = self.icd_rarity_scores.to(device)
 
         cpt_attention_embeds = self.code_attention_pooling(cpt_embeds, cpt_padding_mask, cpt_tokens, self.cpt_rarity_scores)

--- a/jepa_models/hierarchical_model.py
+++ b/jepa_models/hierarchical_model.py
@@ -278,12 +278,27 @@ class HierarchicalClaimsModel(pl.LightningModule):
                 k=config.sae_k,
             )
             if self.use_gated_fusion:
-                self.sae_to_embed = nn.Linear(config.sae_hidden_dim, config.embedding_dim)
+                # Map the SAE hidden representation to the patient representation
+                # dimension. This ensures that the SAE embedding and the patient
+                # representation have matching sizes even when
+                # ``use_context_pooled_patient_representation`` doubles the
+                # dimensionality.
+                self.sae_to_embed = nn.Linear(
+                    config.sae_hidden_dim, config.patient_representation_dim
+                )
+                # The gating network takes the concatenation of the patient
+                # representation and SAE embedding and outputs a gating vector of
+                # the same dimensionality as ``patient_representation``.
                 self.gating_network = nn.Sequential(
-                    nn.Linear(config.patient_representation_dim + config.embedding_dim, config.gating_hidden_dim),
+                    nn.Linear(
+                        config.patient_representation_dim * 2,
+                        config.gating_hidden_dim,
+                    ),
                     nn.ReLU(),
-                    nn.Linear(config.gating_hidden_dim, config.embedding_dim),
-                    nn.Sigmoid()
+                    nn.Linear(
+                        config.gating_hidden_dim, config.patient_representation_dim
+                    ),
+                    nn.Sigmoid(),
                 )
 
         self.lr = config.lr


### PR DESCRIPTION
## Summary
- ensure SAE embeddings match patient representation shape for gated fusion
- treat rarity score tensors as optional in Level2Encoder
- guard `.to(device)` calls with `isinstance(..., torch.Tensor)`

## Testing
- `python -m unittest discover -v`