### PR TITLE
Add diffusion generator option

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ monitor how much the model relies on the SAE representation.  This mechanism
 improves training stability by letting the pretrained SAE guide the hierarchical
 encoders during early epochs.
 
+## Diffusion Generator
+
+Set `use_diffusion = True` in `Config` to train and sample from a denoising diffusion model.
+The diffusion generator produces CPT, ICD and TTNC tokens and can replace the
+heuristic generator during inference.
+
 # Future state
 I'm considering adding a GAN back to the public version.
 It'd also be nice to extend the generator to longer sequences of claims.

--- a/jepa_models/diffusion.py
+++ b/jepa_models/diffusion.py
@@ -1,0 +1,103 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import pytorch_lightning as pl
+
+class DiffusionModel(pl.LightningModule):
+    """Simple DDPM for CPT/ICD/TTNC token generation."""
+
+    def __init__(self, config):
+        super().__init__()
+        self.save_hyperparameters()
+        self.embedding_dim = config.embedding_dim
+        self.cpt_vocab_size = config.cpt_vocab_size
+        self.icd_vocab_size = config.icd_vocab_size
+        self.ttnc_vocab_size = config.ttnc_vocab_size
+        self.num_timesteps = getattr(config, 'diffusion_steps', 100)
+
+        betas = torch.linspace(1e-4, 0.02, self.num_timesteps)
+        alphas = 1.0 - betas
+        alphas_cumprod = torch.cumprod(alphas, dim=0)
+        self.register_buffer('betas', betas)
+        self.register_buffer('alphas_cumprod', alphas_cumprod)
+        self.register_buffer('sqrt_alphas_cumprod', torch.sqrt(alphas_cumprod))
+        self.register_buffer('sqrt_one_minus_alphas_cumprod', torch.sqrt(1.0 - alphas_cumprod))
+
+        self.time_embed = nn.Embedding(self.num_timesteps, self.embedding_dim * 3)
+
+        self.cpt_embedding = nn.Embedding(self.cpt_vocab_size, self.embedding_dim)
+        self.icd_embedding = nn.Embedding(self.icd_vocab_size, self.embedding_dim)
+        self.ttnc_embedding = nn.Embedding(self.ttnc_vocab_size, self.embedding_dim)
+
+        self.model = nn.Sequential(
+            nn.Linear(self.embedding_dim * 3, self.embedding_dim * 6),
+            nn.ReLU(),
+            nn.Linear(self.embedding_dim * 6, self.embedding_dim * 3),
+        )
+
+        self.cpt_proj = nn.Linear(self.embedding_dim, self.cpt_vocab_size)
+        self.icd_proj = nn.Linear(self.embedding_dim, self.icd_vocab_size)
+        self.ttnc_proj = nn.Linear(self.embedding_dim, self.ttnc_vocab_size)
+
+        self.lr = config.lr
+
+    def q_sample(self, x_start, t, noise):
+        sqrt_acp = self.sqrt_alphas_cumprod[t].unsqueeze(1)
+        sqrt_om_acp = self.sqrt_one_minus_alphas_cumprod[t].unsqueeze(1)
+        return sqrt_acp * x_start + sqrt_om_acp * noise
+
+    def p_losses(self, x_start, t, noise):
+        x_noisy = self.q_sample(x_start, t, noise)
+        t_emb = self.time_embed(t)
+        predicted = self.model(x_noisy + t_emb)
+        return F.mse_loss(predicted, noise)
+
+    def aggregate_tokens(self, cpt_tokens, icd_tokens, ttnc_tokens):
+        cpt_emb = self.cpt_embedding(cpt_tokens).sum(dim=1)
+        icd_emb = self.icd_embedding(icd_tokens).sum(dim=1)
+        ttnc_emb = self.ttnc_embedding(ttnc_tokens)
+        return torch.cat([cpt_emb, icd_emb, ttnc_emb], dim=1)
+
+    def forward(self, cpt_tokens, icd_tokens, ttnc_tokens):
+        x_start = self.aggregate_tokens(cpt_tokens, icd_tokens, ttnc_tokens)
+        batch_size = x_start.size(0)
+        t = torch.randint(0, self.num_timesteps, (batch_size,), device=x_start.device).long()
+        noise = torch.randn_like(x_start)
+        loss = self.p_losses(x_start, t, noise)
+        return loss
+
+    @torch.no_grad()
+    def sample(self, batch_size):
+        device = self.betas.device
+        x = torch.randn(batch_size, self.embedding_dim * 3, device=device)
+        for step in reversed(range(self.num_timesteps)):
+            t = torch.full((batch_size,), step, device=device, dtype=torch.long)
+            t_emb = self.time_embed(t)
+            noise_pred = self.model(x + t_emb)
+            coef1 = 1 / torch.sqrt(1 - self.betas[step])
+            coef2 = self.betas[step] / torch.sqrt(1 - self.alphas_cumprod[step])
+            x = coef1 * (x - coef2 * noise_pred)
+            if step > 0:
+                noise = torch.randn_like(x)
+                sigma = torch.sqrt(self.betas[step])
+                x += sigma * noise
+
+        cpt_logits = self.cpt_proj(x[:, :self.embedding_dim])
+        icd_logits = self.icd_proj(x[:, self.embedding_dim:2 * self.embedding_dim])
+        ttnc_logits = self.ttnc_proj(x[:, 2 * self.embedding_dim:])
+        cpt_tokens = torch.argmax(cpt_logits, dim=-1)
+        icd_tokens = torch.argmax(icd_logits, dim=-1)
+        ttnc_token = torch.argmax(ttnc_logits, dim=-1)
+        return cpt_tokens, icd_tokens, ttnc_token
+
+    def training_step(self, batch, batch_idx):
+        cpt_tensor, icd_tensor, ttnc_tensor, _ = batch
+        cpt_tokens = cpt_tensor[:, -1, :]
+        icd_tokens = icd_tensor[:, -1, :]
+        ttnc_tokens = ttnc_tensor[:, -1]
+        loss = self.forward(cpt_tokens, icd_tokens, ttnc_tokens)
+        self.log('diffusion_loss', loss, on_step=False, on_epoch=True, prog_bar=True, logger=True)
+        return loss
+
+    def configure_optimizers(self):
+        return torch.optim.Adam(self.parameters(), lr=self.lr)

--- a/jepa_models/hierarchical_model.py
+++ b/jepa_models/hierarchical_model.py
@@ -7,6 +7,7 @@ import pytorch_lightning as pl
 import numpy as np
 from jepa_models.encoders import Level1Encoder, Level2Encoder
 from jepa_models.prediction_blocks import Level1PredictionBlock, Level2PredictionBlock, LogitsGenerator
+from jepa_models.diffusion import DiffusionModel
 from jepa_models.sparse_autoencoder import SparseAutoencoder
 from jepa_utils.metrics import calculate_rmse
 from jepa_utils.tensor_utils import calculate_entropy
@@ -192,6 +193,7 @@ class HierarchicalClaimsModel(pl.LightningModule):
         self.use_token_prediction_head = config.use_token_prediction_head
         self.use_sparse_autoencoder = config.use_sparse_autoencoder
         self.use_gated_fusion = config.use_gated_fusion
+        self.use_diffusion = getattr(config, 'use_diffusion', False)
         self.cpt_vocab_size=config.cpt_vocab_size,
         self.icd_vocab_size=config.icd_vocab_size,
 
@@ -324,6 +326,9 @@ class HierarchicalClaimsModel(pl.LightningModule):
 
         if self.use_token_prediction_head:
             self.logits_generator = LogitsGenerator(config)
+
+        if self.use_diffusion:
+            self.diffusion_model = DiffusionModel(config)
 
         # self.discriminator = nn.Sequential(
         #     nn.Linear(config.embedding_dim, config.hidden_dim),
@@ -767,6 +772,14 @@ class HierarchicalClaimsModel(pl.LightningModule):
     def autoregressive_generation(self, cpt_tensor, icd_tensor, ttnc_tensor):
         batch_size = cpt_tensor.size(0)
         # self.reset_generated_sets(batch_size)
+
+        if self.use_diffusion:
+            cpt_tokens, icd_tokens, ttnc_token = self.diffusion_model.sample(batch_size)
+            return {
+                'predicted_cpt_codes': cpt_tokens,
+                'predicted_icd_codes': icd_tokens,
+                'predicted_ttnc_code': ttnc_token,
+            }
 
         # Obtain initial patient representation
         context_lvl2 = self.context_encoder_lvl2(cpt_tensor, icd_tensor, ttnc_tensor)

--- a/jepa_utils/config.py
+++ b/jepa_utils/config.py
@@ -50,6 +50,8 @@ class Config:
     use_generative_save = False
     use_sparse_autoencoder: bool = True
     use_gated_fusion: bool = True
+    use_diffusion: bool = False
+    diffusion_steps: int = 100
     sae_hidden_dim: int = 256
     sae_k: int = 10
     gating_hidden_dim: int = 256

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -11,6 +11,7 @@ from tqdm import tqdm
 from torch.utils.data import DataLoader
 from jepa_models.data_prep import prepare_data
 from jepa_models.hierarchical_model import HierarchicalClaimsModel
+from jepa_models.diffusion import DiffusionModel
 from jepa_utils.tensor_utils import calculate_entropy, adaptive_sampling
 from jepa_utils.metrics import calculate_rmse
 from jepa_utils.config import Config
@@ -22,6 +23,16 @@ def main():
 
     print('Preparing Data')
     train_dataset, train_dataloader, eval_dataset, eval_dataloader, config, dataset = prepare_data(config)
+
+    if config.use_diffusion:
+        diffusion_model = DiffusionModel(config)
+        diffusion_trainer = pl.Trainer(
+            max_epochs=config.epochs,
+            accelerator='gpu',
+            logger=pl.loggers.TensorBoardLogger("tb_logs", name="diffusion"),
+            callbacks=[RichProgressBar(refresh_rate=1)]
+        )
+        diffusion_trainer.fit(diffusion_model, train_dataloader)
 
     # Initialize model
     print('max claims len', config.max_claims_len)

--- a/tests/test_diffusion.py
+++ b/tests/test_diffusion.py
@@ -1,0 +1,26 @@
+import unittest
+import torch
+from jepa_utils.config import Config
+from jepa_models.diffusion import DiffusionModel
+
+class TestDiffusionModel(unittest.TestCase):
+    def test_forward_and_sample(self):
+        config = Config()
+        config.cpt_vocab_size = 10
+        config.icd_vocab_size = 10
+        config.ttnc_vocab_size = 5
+        config.embedding_dim = 4
+        config.diffusion_steps = 5
+        model = DiffusionModel(config)
+        cpt_tokens = torch.randint(0, 10, (2, config.max_cpt_tokens))
+        icd_tokens = torch.randint(0, 10, (2, config.max_icd_tokens))
+        ttnc_tokens = torch.randint(0, 5, (2,))
+        loss = model(cpt_tokens, icd_tokens, ttnc_tokens)
+        self.assertTrue(loss.dim() == 0)
+        cpt_pred, icd_pred, ttnc_pred = model.sample(2)
+        self.assertEqual(cpt_pred.shape, (2,))
+        self.assertEqual(icd_pred.shape, (2,))
+        self.assertEqual(ttnc_pred.shape, (2,))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a `DiffusionModel` implementing a basic DDPM
- support optional diffusion generation in `HierarchicalClaimsModel`
- allow training the diffusion model in `scripts/train.py`
- document the new setting in `README`
- test the new diffusion module

## Testing
- `pytest -q`