### PR TITLE
Add diffusion loss to hierarchical model

### DIFF
--- a/jepa_models/hierarchical_model.py
+++ b/jepa_models/hierarchical_model.py
@@ -193,6 +193,7 @@ class HierarchicalClaimsModel(pl.LightningModule):
         self.use_sparse_autoencoder = config.use_sparse_autoencoder
         self.use_gated_fusion = config.use_gated_fusion
         self.use_diffusion = getattr(config, 'use_diffusion', False)
+        self.diffusion_weight = getattr(config, 'diffusion_weight', 1.0)
         self.cpt_vocab_size=config.cpt_vocab_size,
         self.icd_vocab_size=config.icd_vocab_size,
 
@@ -311,6 +312,7 @@ class HierarchicalClaimsModel(pl.LightningModule):
             'task': nn.Parameter(torch.zeros(1)),
             'token_pred': nn.Parameter(torch.zeros(1)),
             'sae': nn.Parameter(torch.zeros(1)),
+            'diffusion': nn.Parameter(torch.zeros(1)),
             #'adversarial': nn.Parameter(torch.zeros(1)),
         })
 
@@ -429,13 +431,14 @@ class HierarchicalClaimsModel(pl.LightningModule):
 
         return vicreg_loss, var_loss, inv_loss
 
-    def calculate_total_loss(self, vicreg_loss_lvl1, vicreg_loss_lvl2, task_loss, lvl2_weight, token_pred_loss, sae_loss=0):
+    def calculate_total_loss(self, vicreg_loss_lvl1, vicreg_loss_lvl2, task_loss, lvl2_weight, token_pred_loss, sae_loss=0, diffusion_loss=0):
         # Conceptually - https://arxiv.org/pdf/1705.07115
         log_var_denom = 2
         log_var_denom += 1 if self.use_level1 else 0
         log_var_denom += 1 if self.use_predictor_head else 0
         log_var_denom += 1 if self.use_token_prediction_head else 0
         log_var_denom += 1 if self.use_sparse_autoencoder else 0
+        log_var_denom += 1 if self.use_diffusion else 0
 
 
         clamped_log_vars = {k: torch.clamp(v, min=-10, max=10) for k, v in self.log_vars.items()}
@@ -477,6 +480,13 @@ class HierarchicalClaimsModel(pl.LightningModule):
             total_loss = total_loss + weighted_sae_loss
             total_precision = total_precision + precision_sae
             total_log_var = total_log_var + clamped_log_vars['sae']
+
+        if self.use_diffusion:
+            precision_diff = torch.exp(clamped_log_vars['diffusion'])
+            weighted_diff_loss = diffusion_loss * precision_diff * self.diffusion_weight
+            total_loss = total_loss + weighted_diff_loss
+            total_precision = total_precision + precision_diff
+            total_log_var = total_log_var + clamped_log_vars['diffusion']
 
             # precision_adv = torch.exp(clamped_log_vars['adversarial'])
             # total_loss += adversarial_loss * precision_adv
@@ -665,12 +675,11 @@ class HierarchicalClaimsModel(pl.LightningModule):
             task_loss = self.loss_fn(target_pred, target_normalized)
 
         token_pred_loss = 0  # Initialize token prediction loss
+        logit_context = prediction_lvl2
         if self.use_token_prediction_head:
             # Initialize generated sets
             batch_size = cpt_tensor.size(0)
             #self.reset_generated_sets(batch_size)
-
-            logit_context = prediction_lvl2
             if teacher_forcing:
                 # Use ground truth initial CPT code
                 initial_cpt = target_cpt.squeeze(1)[:, 0]  # First CPT code
@@ -748,6 +757,7 @@ class HierarchicalClaimsModel(pl.LightningModule):
             'var_pred_lvl1': embedding_variance_lvl1,
             'var_pred_lvl2': embedding_variance_lvl2,
             'patient_representation': patient_representation,
+            'logit_context': prediction_lvl2,
             'task_loss': task_loss,
             'token_pred_loss': token_pred_loss,
             'sae_loss': sae_loss,
@@ -851,6 +861,18 @@ class HierarchicalClaimsModel(pl.LightningModule):
             generation=False
         )
 
+        diffusion_loss = 0
+        if self.use_diffusion:
+            cpt_tokens = batch[0][:, -1, :]
+            icd_tokens = batch[1][:, -1, :]
+            ttnc_tokens = batch[2][:, -1]
+            diffusion_loss = self.diffusion_model.forward(
+                cpt_tokens,
+                icd_tokens,
+                ttnc_tokens,
+                condition=outputs['logit_context'],
+            )
+
         # Total loss calculation
         total_loss, task_loss = self.calculate_total_loss(
             vicreg_loss_lvl1=outputs['vicreg_loss_lvl1'],
@@ -858,11 +880,15 @@ class HierarchicalClaimsModel(pl.LightningModule):
             task_loss=outputs['task_loss'],
             lvl2_weight=self.level_2_weight,
             token_pred_loss=outputs['token_pred_loss'],
-            sae_loss=outputs['sae_loss']
+            sae_loss=outputs['sae_loss'],
+            diffusion_loss=diffusion_loss,
         )
 
         # --- Logging ---
         self.log('loss', total_loss, on_step=False, on_epoch=True, prog_bar=True, logger=True)
+
+        if self.use_diffusion:
+            self.log('diffusion_loss', diffusion_loss, on_step=False, on_epoch=True, prog_bar=True, logger=True)
 
         # Preserve existing logging
         if self.use_token_prediction_head:

--- a/jepa_utils/config.py
+++ b/jepa_utils/config.py
@@ -51,6 +51,7 @@ class Config:
     use_sparse_autoencoder: bool = True
     use_gated_fusion: bool = True
     use_diffusion: bool = False  # Toggle diffusion-based claim generation
+    diffusion_weight: float = 1.0  # Weight for diffusion loss when joint training
     diffusion_steps: int = 100
     sae_hidden_dim: int = 256
     sae_k: int = 10

--- a/tests/test_diffusion_integration.py
+++ b/tests/test_diffusion_integration.py
@@ -18,6 +18,7 @@ class TestDiffusionIntegration(unittest.TestCase):
         config.icd_vocab_size = 10
         config.ttnc_vocab_size = 5
         config.embedding_dim = 4
+        config.output_dim = config.embedding_dim
         config.max_cpt_tokens = 3
         config.max_icd_tokens = 3
         config.max_claims_len = 2
@@ -25,14 +26,44 @@ class TestDiffusionIntegration(unittest.TestCase):
 
         model = HierarchicalClaimsModel(config)
         batch_size = 2
-        cpt_tensor = torch.randint(0, config.cpt_vocab_size, (batch_size, config.max_claims_len, config.max_cpt_tokens))
-        icd_tensor = torch.randint(0, config.icd_vocab_size, (batch_size, config.max_claims_len, config.max_icd_tokens))
-        ttnc_tensor = torch.randint(0, config.ttnc_vocab_size, (batch_size, config.max_claims_len))
+        cpt_tensor = torch.randint(1, config.cpt_vocab_size, (batch_size, config.max_claims_len, config.max_cpt_tokens))
+        icd_tensor = torch.randint(1, config.icd_vocab_size, (batch_size, config.max_claims_len, config.max_icd_tokens))
+        ttnc_tensor = torch.randint(1, config.ttnc_vocab_size, (batch_size, config.max_claims_len))
 
         outputs = model.autoregressive_generation(cpt_tensor, icd_tensor, ttnc_tensor)
         self.assertEqual(outputs['predicted_cpt_codes'].shape, (batch_size,))
         self.assertEqual(outputs['predicted_icd_codes'].shape, (batch_size,))
         self.assertEqual(outputs['predicted_ttnc_code'].shape, (batch_size,))
+
+    def test_training_step_with_diffusion_loss(self):
+        config = Config()
+        config.use_diffusion = True
+        config.use_sparse_autoencoder = False
+        config.use_token_prediction_head = False
+        config.use_predictor_head = False
+        config.cpt_rarity_scores = None
+        config.icd_rarity_scores = None
+        config.ttnc_rarity_scores = None
+        config.cpt_vocab_size = 10
+        config.icd_vocab_size = 10
+        config.ttnc_vocab_size = 5
+        config.embedding_dim = 4
+        config.output_dim = config.embedding_dim
+        config.max_cpt_tokens = 3
+        config.max_icd_tokens = 3
+        config.max_claims_len = 2
+        config.diffusion_steps = 5
+
+        model = HierarchicalClaimsModel(config)
+        batch_size = 2
+        cpt_tensor = torch.randint(1, config.cpt_vocab_size, (batch_size, config.max_claims_len, config.max_cpt_tokens))
+        icd_tensor = torch.randint(1, config.icd_vocab_size, (batch_size, config.max_claims_len, config.max_icd_tokens))
+        ttnc_tensor = torch.randint(1, config.ttnc_vocab_size, (batch_size, config.max_claims_len))
+        target = torch.randn(batch_size)
+        batch = (cpt_tensor, icd_tensor, ttnc_tensor, target)
+
+        loss = model.training_step(batch, 0)
+        self.assertIsInstance(loss, torch.Tensor)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- integrate diffusion loss into `HierarchicalClaimsModel` training
- weight diffusion loss using new `diffusion_weight` config option
- log diffusion loss and include it in total loss calculation
- expose level‑2 predicted representation as `logit_context`
- test diffusion loss computation in training

## Testing
- `pytest -q`