### PR TITLE
Bug fixes and debug flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,18 @@ Install the dependencies with:
 pip install -r requirements.txt
 ```
 
+## Quick-start debug
+
+If CPT or ICD predictions look empty, toggle a helper flag:
+
+```python
+config.debug_low_threshold = True
+```
+
+This sets the model's generation threshold to `0.05` and disables the
+entropy term so logits fire during sanity checks. Remember to set it
+back to `False` before real training.
+
 # What can I do with this thing?
 Self-supervised models shine where you have a ton of unlabeled data and you want to maximize value from the labeled data you do have.
 Claims often have missing/incorrect entries.  Commercial directories and downloads from CMS are often wrong or simply outdated.

--- a/agents.md
+++ b/agents.md
@@ -92,3 +92,8 @@ Codex agents must respect `use_diffusion` config toggle. Never invoke both gener
   - `RichProgressBar`
   - `RichModelSummary`
 
+Additional config flags:
+  - `pretrain_diffusion_epochs`: number of epochs to pretrain diffusion
+  - `freeze_transferred_embeddings`: freeze copied embeddings for initial epochs
+  - `debug_low_threshold`: sets `threshold` to `0.05` and disables entropy when true
+

--- a/jepa_models/hierarchical_model.py
+++ b/jepa_models/hierarchical_model.py
@@ -196,8 +196,8 @@ class HierarchicalClaimsModel(pl.LightningModule):
         self.use_diffusion = getattr(config, 'use_diffusion', False)
         self.diffusion_type = getattr(config, 'diffusion_type', 'continuous')
         self.diffusion_weight = getattr(config, 'diffusion_weight', 1.0)
-        self.cpt_vocab_size=config.cpt_vocab_size,
-        self.icd_vocab_size=config.icd_vocab_size,
+        self.cpt_vocab_size = config.cpt_vocab_size
+        self.icd_vocab_size = config.icd_vocab_size
 
         self.accumulated_representations = []
         self.accumulated_targets = []
@@ -685,8 +685,8 @@ class HierarchicalClaimsModel(pl.LightningModule):
                 cpt_logits, icd_logits, ttnc_logits = self.logits_generator(logit_context)
 
                 # Create multi-hot target vectors
-                target_cpt_multi_hot = self.create_multi_hot_targets(target_cpt, self.cpt_vocab_size[0], padding_idx=0)
-                target_icd_multi_hot = self.create_multi_hot_targets(target_icd, self.icd_vocab_size[0], padding_idx=0)
+                target_cpt_multi_hot = self.create_multi_hot_targets(target_cpt, self.cpt_vocab_size, padding_idx=0)
+                target_icd_multi_hot = self.create_multi_hot_targets(target_icd, self.icd_vocab_size, padding_idx=0)
 
                 # Compute loss using targets
                 criterion_bce = nn.BCEWithLogitsLoss()

--- a/jepa_utils/config.py
+++ b/jepa_utils/config.py
@@ -55,9 +55,12 @@ class Config:
     # training the main hierarchical model. Kept ``True`` for backwards
     # compatibility.
     pretrain_diffusion: bool = False
+    pretrain_diffusion_epochs: int = 3
     diffusion_weight: float = 1.0  # Weight for diffusion loss when joint training
     diffusion_type: str = "continuous"  # continuous | discrete
     diffusion_steps: int = 100
+    freeze_transferred_embeddings: bool = True
+    debug_low_threshold: bool = False
     sae_hidden_dim: int = 256
     sae_k: int = 10
     gating_hidden_dim: int = 256

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -43,6 +43,10 @@ def main():
     except Exception as e:
         print(f"Error during model instantiation: {e}")
 
+    if getattr(config, "debug_low_threshold", False):
+        model.threshold.data = torch.tensor(0.05)
+        model.lambda_entropy.data = torch.tensor(0.0)
+
     # Initialize Trainer
     trainer = pl.Trainer(
         max_epochs=config.epochs,

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,6 @@ from setuptools import setup, find_packages
 
 setup(
     name="jepa_models",
-    version="0.1.0",
+    version="0.1.1",
     packages=find_packages(),
 )

--- a/tests/test_debug_threshold.py
+++ b/tests/test_debug_threshold.py
@@ -1,0 +1,42 @@
+import unittest
+import torch
+from jepa_utils.config import Config
+from jepa_models.hierarchical_model import HierarchicalClaimsModel
+
+class TestDebugLowThreshold(unittest.TestCase):
+    def test_threshold_flag_sets_values(self):
+        config = Config()
+        config.cpt_vocab_size = 5
+        config.icd_vocab_size = 5
+        config.ttnc_vocab_size = 3
+        config.cpt_rarity_scores = None
+        config.icd_rarity_scores = None
+        config.ttnc_rarity_scores = None
+        config.use_diffusion = False
+        config.debug_low_threshold = True
+
+        model = HierarchicalClaimsModel(config)
+        if getattr(config, 'debug_low_threshold', False):
+            model.threshold.data = torch.tensor(0.05)
+            model.lambda_entropy.data = torch.tensor(0.0)
+
+        self.assertAlmostEqual(model.threshold.item(), 0.05)
+        self.assertAlmostEqual(model.lambda_entropy.item(), 0.0)
+
+class TestVocabSizeTypes(unittest.TestCase):
+    def test_vocab_sizes_are_int(self):
+        config = Config()
+        config.cpt_vocab_size = 7
+        config.icd_vocab_size = 9
+        config.ttnc_vocab_size = 3
+        config.cpt_rarity_scores = None
+        config.icd_rarity_scores = None
+        config.ttnc_rarity_scores = None
+        config.use_diffusion = False
+
+        model = HierarchicalClaimsModel(config)
+        self.assertIsInstance(model.cpt_vocab_size, int)
+        self.assertIsInstance(model.icd_vocab_size, int)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- fix trailing comma that made vocab size tuple
- expose debug_low_threshold and other config flags
- toggle low threshold in training when debug flag is set
- document debug flag in README and agents.md
- bump patch version
- test threshold helper and vocab-size bug

## Testing
- `pytest -q`