### PR TITLE
Fix diffusion token shapes

### DIFF
--- a/jepa_models/diffusion.py
+++ b/jepa_models/diffusion.py
@@ -68,6 +68,15 @@ class DiffusionModel(pl.LightningModule):
         return F.mse_loss(predicted, noise)
 
     def aggregate_tokens(self, cpt_tokens, icd_tokens, ttnc_tokens):
+        """Aggregate token embeddings into a single representation."""
+        # ``cpt_tokens`` and ``icd_tokens`` may come in as 1D tensors when only
+        # a single code per claim is used. Ensure we always have a sequence
+        # dimension so ``sum(dim=1)`` works for both cases.
+        if cpt_tokens.dim() == 1:
+            cpt_tokens = cpt_tokens.unsqueeze(1)
+        if icd_tokens.dim() == 1:
+            icd_tokens = icd_tokens.unsqueeze(1)
+
         cpt_emb = self.cpt_embedding(cpt_tokens).sum(dim=1)
         icd_emb = self.icd_embedding(icd_tokens).sum(dim=1)
         ttnc_emb = self.ttnc_embedding(ttnc_tokens)

--- a/jepa_models/discrete_diffusion.py
+++ b/jepa_models/discrete_diffusion.py
@@ -50,12 +50,22 @@ class DiscreteDiffusionModel(pl.LightningModule):
         self.max_icd_tokens = config.max_icd_tokens
 
     def q_sample(self, tokens, vocab_size, t):
-        prob = self.betas[t].unsqueeze(1)
+        """Perform a single diffusion step on the provided tokens."""
+        # ``t`` has shape [batch_size]. Adapt the beta values to match the
+        # dimensionality of ``tokens`` so broadcasting works for both 1-D and
+        # 2-D token tensors.
+        prob = self.betas[t].view(tokens.size(0), *([1] * (tokens.dim() - 1)))
         noise = torch.randint(0, vocab_size, tokens.shape, device=tokens.device)
         mask = torch.bernoulli(prob.expand_as(tokens)).bool()
         return torch.where(mask, noise, tokens)
 
     def aggregate_tokens(self, cpt_tokens, icd_tokens, ttnc_tokens):
+        """Aggregate embeddings for CPT, ICD and TTNC tokens."""
+        if cpt_tokens.dim() == 1:
+            cpt_tokens = cpt_tokens.unsqueeze(1)
+        if icd_tokens.dim() == 1:
+            icd_tokens = icd_tokens.unsqueeze(1)
+
         cpt_emb = self.cpt_embedding(cpt_tokens).sum(dim=1)
         icd_emb = self.icd_embedding(icd_tokens).sum(dim=1)
         ttnc_emb = self.ttnc_embedding(ttnc_tokens)

--- a/jepa_models/hierarchical_model.py
+++ b/jepa_models/hierarchical_model.py
@@ -719,16 +719,19 @@ class HierarchicalClaimsModel(pl.LightningModule):
                 # ─── Diffusion loss for the last-claim reconstruction ─────────
         diffusion_loss = torch.tensor(0.0, device=self.device)          # default no-op
         if self.use_diffusion:
-            # tokens from the LAST claim in this batch
-            cpt_last  = target_cpt.squeeze(1)[:, 0]           # shape [batch]
-            icd_last  = target_icd.squeeze(1)[:, 0]
-            ttnc_last = target_ttnc.squeeze(1)     # shape [batch]
+            # Tokens from the last claim in the batch. ``target_*`` has shape
+            # ``[batch, 1, num_tokens]`` so we remove the claim dimension but
+            # retain the per-code dimension for CPT/ICD. TTNC is a single code
+            # per claim so it becomes ``[batch]``.
+            cpt_last = target_cpt.squeeze(1)  # [batch, max_cpt_tokens]
+            icd_last = target_icd.squeeze(1)  # [batch, max_icd_tokens]
+            ttnc_last = target_ttnc.squeeze(1)  # [batch]
 
             diffusion_loss = self.diffusion_model.forward(
                 cpt_last,
                 icd_last,
                 ttnc_last,
-                condition=prediction_lvl2,                    # predicted claim rep
+                condition=prediction_lvl2,  # predicted claim rep
             )
 
         # Compute total loss


### PR DESCRIPTION
## Summary
- support 1D token inputs in diffusion models
- handle diffusion tokens correctly in `training_forward`
- make discrete diffusion's q_sample broadcast safely

## Testing
- `pytest -q`