### PR TITLE
Add encoder freezing helpers and training schedule

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -95,5 +95,20 @@ Codex agents must respect `use_diffusion` config toggle. Never invoke both gener
 Additional config flags:
   - `pretrain_diffusion_epochs`: number of epochs to pretrain diffusion
   - `freeze_transferred_embeddings`: freeze copied embeddings for initial epochs
+  - `encoder_unfreeze_layers`: layers left trainable when encoders are frozen
   - `debug_low_threshold`: sets `threshold` to `0.05` and disables entropy when true
+
+### 🏋️ Training Schedule
+
+1. **Stage 1 – Representation Pretrain**
+   - `use_token_prediction_head = False`
+   - `use_diffusion = False`
+   - Stop when VICReg or SAE loss plateaus.
+
+2. **Stage 2 – Generator Training**
+   - Load `encoder_only.ckpt`, then call `freeze_encoders()` with `encoder_unfreeze_layers`.
+   - Enable `use_token_prediction_head` and `use_diffusion` with `diffusion_weight ≈ 0.1-0.2`.
+
+3. **Stage 3 – Joint Fine‑Tune (optional)**
+   - `unfreeze_encoders()` and train all losses with a lower encoder LR.
 

--- a/jepa_models/hierarchical_model.py
+++ b/jepa_models/hierarchical_model.py
@@ -344,6 +344,38 @@ class HierarchicalClaimsModel(pl.LightningModule):
 
         self.initialize_target_encoders()
 
+    def _unfreeze_last_n(self, module, n_layers):
+        """Helper to unfreeze the last ``n_layers`` child modules of ``module``."""
+        for param in module.parameters():
+            param.requires_grad = False
+        if n_layers <= 0:
+            return
+        children = list(module.children())
+        if not children:
+            for param in module.parameters():
+                param.requires_grad = True
+            return
+        for child in children[-n_layers:]:
+            for param in child.parameters():
+                param.requires_grad = True
+
+    def freeze_encoders(self, n_layers: int = 1):
+        """Freeze all encoder weights except the last ``n_layers``."""
+        modules = [self.context_encoder_lvl2, self.target_encoder_lvl2]
+        if self.use_level1:
+            modules.extend([self.context_encoder_lvl1, self.target_encoder_lvl1])
+        for mod in modules:
+            self._unfreeze_last_n(mod, n_layers)
+
+    def unfreeze_encoders(self):
+        """Unfreeze all encoder parameters."""
+        modules = [self.context_encoder_lvl2, self.target_encoder_lvl2]
+        if self.use_level1:
+            modules.extend([self.context_encoder_lvl1, self.target_encoder_lvl1])
+        for mod in modules:
+            for param in mod.parameters():
+                param.requires_grad = True
+
     def initialize_target_encoders(self):
         if self.use_level1:
             for param_q, param_k in zip(self.context_encoder_lvl1.parameters(), self.target_encoder_lvl1.parameters()):

--- a/jepa_utils/config.py
+++ b/jepa_utils/config.py
@@ -60,6 +60,7 @@ class Config:
     diffusion_type: str = "continuous"  # continuous | discrete
     diffusion_steps: int = 100
     freeze_transferred_embeddings: bool = False
+    encoder_unfreeze_layers: int = 1
     debug_low_threshold: bool = False
     sae_hidden_dim: int = 256
     sae_k: int = 10

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -43,6 +43,9 @@ def main():
     except Exception as e:
         print(f"Error during model instantiation: {e}")
 
+    if getattr(config, "freeze_transferred_embeddings", False):
+        model.freeze_encoders(getattr(config, "encoder_unfreeze_layers", 1))
+
     if getattr(config, "debug_low_threshold", False):
         model.threshold.data = torch.tensor(0.05)
         model.lambda_entropy.data = torch.tensor(0.0)

--- a/tests/test_freeze_unfreeze.py
+++ b/tests/test_freeze_unfreeze.py
@@ -1,0 +1,23 @@
+import unittest
+from jepa_utils.config import Config
+from jepa_models.hierarchical_model import HierarchicalClaimsModel
+
+class TestFreezeUnfreeze(unittest.TestCase):
+    def test_freeze_and_unfreeze(self):
+        cfg = Config()
+        cfg.cpt_vocab_size = 5
+        cfg.icd_vocab_size = 5
+        cfg.ttnc_vocab_size = 3
+        cfg.cpt_rarity_scores = None
+        cfg.icd_rarity_scores = None
+        cfg.ttnc_rarity_scores = None
+        cfg.use_diffusion = False
+        model = HierarchicalClaimsModel(cfg)
+        model.freeze_encoders(1)
+        frozen = [p.requires_grad for p in model.context_encoder_lvl2.parameters()]
+        self.assertTrue(any(not f for f in frozen))
+        model.unfreeze_encoders()
+        self.assertTrue(all(p.requires_grad for p in model.context_encoder_lvl2.parameters()))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- support freezing and unfreezing encoder layers
- expose `encoder_unfreeze_layers` in Config
- allow `train.py` to freeze encoders when configured
- test new freeze/unfreeze helpers
- document 3‑stage training procedure in `agents.md`

## Testing
- `pytest -q`