### PR TITLE
Add TopKActivation index validation

### DIFF
--- a/jepa_models/sparse_autoencoder.py
+++ b/jepa_models/sparse_autoencoder.py
@@ -11,10 +11,17 @@ class TopKActivation(nn.Module):
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         if self.k >= x.size(1):
             return x
-        # Determine the threshold for top-k (by absolute value)
-        topk_values = torch.topk(x.abs(), self.k, dim=1).values
-        kth_vals = topk_values[:, -1].unsqueeze(1)
-        mask = x.abs() >= kth_vals
+
+        # Indices of the top-k values by absolute magnitude
+        _, topk_indices = torch.topk(x.abs(), self.k, dim=1)
+
+        mask = torch.zeros_like(x, dtype=torch.bool)
+        mask.scatter_(1, topk_indices, True)
+
+        # Verify mask selects exactly k indices per sample during debugging
+        if __debug__:
+            assert torch.all(mask.sum(dim=1) == self.k), "TopKActivation mask incorrect"
+
         return x * mask.float()
 
 

--- a/tests/test_sparse_autoencoder.py
+++ b/tests/test_sparse_autoencoder.py
@@ -1,0 +1,19 @@
+import unittest
+import torch
+from jepa_models.sparse_autoencoder import TopKActivation
+
+class TestTopKActivation(unittest.TestCase):
+    def test_topk_indices(self):
+        torch.manual_seed(0)
+        x = torch.tensor([[1.0, -2.0, 0.5, 4.0, -3.0]])
+        activation = TopKActivation(k=3)
+        out = activation(x)
+        # Expected indices of the top 3 absolute values
+        _, expected_idx = torch.topk(x.abs(), 3, dim=1)
+        nonzero_idx = out.nonzero(as_tuple=False)[:, 1]
+        self.assertEqual(set(expected_idx.view(-1).tolist()), set(nonzero_idx.tolist()))
+        self.assertTrue(torch.all(out[:, nonzero_idx] != 0))
+        self.assertTrue((out == 0).sum().item() == x.numel() - 3)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- validate TopK mask creation in `TopKActivation` and keep indices count correct
- test TopK activation to verify indices are selected correctly

## Testing
- `pytest -q`