### PR TITLE
Fix stage1 encoder freeze

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -103,11 +103,13 @@ Additional config flags:
 1. **Stage 1 – Representation Pretrain**
    - `use_token_prediction_head = False`
    - `use_diffusion = False`
+   - Encoder remains fully trainable.
    - Stop when VICReg or SAE loss plateaus.
 
 2. **Stage 2 – Generator Training**
    - Load `encoder_only.ckpt` and freeze encoders using `freeze_encoder(except_last_n_layers=1)`.
    - Keep only adapter layers trainable at **LR ≈ 1e-4** while token head, TTNC classifier and diffusion use **LR ≈ 5e-4**.
+   - Freeze helper checks `config.current_stage` so this only occurs when `current_stage == "stage2"` and `freeze_encoder_at_stage2` is `True`.
    - Perform a one-time gradient check to verify that frozen layers report `grad == None`.
    - Enable `use_token_prediction_head` and `use_diffusion` with `diffusion_weight ≈ 0.1-0.2`.
    - Apply an LR scheduler (e.g. `StepLR(gamma=0.5, step_size=2)`) during this stage.

--- a/jepa_models/hierarchical_model.py
+++ b/jepa_models/hierarchical_model.py
@@ -198,6 +198,7 @@ class HierarchicalClaimsModel(pl.LightningModule):
         self.diffusion_weight = getattr(config, 'diffusion_weight', 1.0)
         self.cpt_vocab_size = config.cpt_vocab_size
         self.icd_vocab_size = config.icd_vocab_size
+        self.is_stage1_pretrain = getattr(config, 'current_stage', 'stage1') == 'stage1'
 
         self.accumulated_representations = []
         self.accumulated_targets = []
@@ -346,6 +347,9 @@ class HierarchicalClaimsModel(pl.LightningModule):
                 )
 
         self.initialize_target_encoders()
+
+        if (not self.is_stage1_pretrain) and getattr(config, 'freeze_encoder_at_stage2', True):
+            self.freeze_encoder(getattr(config, 'encoder_unfreeze_layers', 1))
 
     def _unfreeze_last_n(self, module, n_layers):
         """Helper to unfreeze the last ``n_layers`` child modules of ``module``."""

--- a/jepa_utils/config.py
+++ b/jepa_utils/config.py
@@ -62,7 +62,9 @@ class Config:
     diffusion_type: str = "discrete"  # continuous | discrete
     diffusion_steps: int = 100
     freeze_transferred_embeddings: bool = False
+    freeze_encoder_at_stage2: bool = True
     encoder_unfreeze_layers: int = 1
+    current_stage: str = "stage1"
     debug_low_threshold: bool = False
     sae_hidden_dim: int = 256
     sae_k: int = 10

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -44,7 +44,7 @@ def main():
         else:
             model = HierarchicalClaimsModel(cfg)
 
-        if freeze:
+        if freeze and not model.is_stage1_pretrain and cfg.freeze_encoder_at_stage2:
             model.freeze_encoder(getattr(cfg, "encoder_unfreeze_layers", 1))
 
         if getattr(cfg, "debug_low_threshold", False):
@@ -88,6 +88,7 @@ def main():
         stage_cfg.use_token_prediction_head = False
         stage_cfg.use_diffusion = False
         stage_cfg.epochs = config.representation_pretrain_epochs
+        stage_cfg.current_stage = "stage1"
         model, trainer = train_stage(stage_cfg, "stage1")
         ckpt_path = "encoder_only.ckpt"
         trainer.save_checkpoint(ckpt_path)
@@ -97,12 +98,14 @@ def main():
         stage_cfg.use_token_prediction_head = True
         stage_cfg.use_diffusion = True
         stage_cfg.epochs = config.generator_train_epochs
+        stage_cfg.current_stage = "stage2"
         model, trainer = train_stage(stage_cfg, "stage2", ckpt_path=ckpt_path, freeze=True)
         ckpt_path = "generator_stage.ckpt"
         trainer.save_checkpoint(ckpt_path)
 
     if model is None:
         # Fallback to single stage training with current config
+        config.current_stage = "joint"
         model, trainer = train_stage(config, "jepa")
         ckpt_path = "final.ckpt"
         trainer.save_checkpoint(ckpt_path)
@@ -112,6 +115,7 @@ def main():
         stage_cfg.use_token_prediction_head = True
         stage_cfg.use_diffusion = True
         stage_cfg.epochs = config.joint_train_epochs
+        stage_cfg.current_stage = "joint"
         model, trainer = train_stage(stage_cfg, "joint", ckpt_path=ckpt_path)
         ckpt_path = "joint.ckpt"
         trainer.save_checkpoint(ckpt_path)


### PR DESCRIPTION
## Summary
- add `freeze_encoder_at_stage2` and `current_stage` config flags
- use new `is_stage1_pretrain` property to avoid freezing in stage1
- let `train.py` set `current_stage` for each phase
- document stage-aware freeze behavior

## Testing
- `pytest -q`