### PR TITLE
Fix SAE weighting sign in loss function

### DIFF
--- a/jepa_models/hierarchical_model.py
+++ b/jepa_models/hierarchical_model.py
@@ -515,28 +515,28 @@ class HierarchicalClaimsModel(pl.LightningModule):
         total_log_var = total_log_var + clamped_log_vars['vicreg_lvl2']
 
         if self.use_predictor_head:
-            precision_task = torch.exp(clamped_log_vars['task'])
+            precision_task = torch.exp(-clamped_log_vars['task'])
             weighted_task_loss = task_loss * precision_task
             total_loss = total_loss + weighted_task_loss
             total_precision = total_precision + precision_task
             total_log_var = total_log_var + clamped_log_vars['task']
 
         if self.use_token_prediction_head:
-            precision_token = torch.exp(clamped_log_vars['token_pred'])
+            precision_token = torch.exp(-clamped_log_vars['token_pred'])
             weighted_token_loss = token_pred_loss * precision_token
             total_loss = total_loss + weighted_token_loss
             total_precision = total_precision + precision_token
             total_log_var = total_log_var + clamped_log_vars['token_pred']
 
         if self.use_sparse_autoencoder:
-            precision_sae = torch.exp(clamped_log_vars['sae'])
+            precision_sae = torch.exp(-clamped_log_vars['sae'])
             weighted_sae_loss = sae_loss * precision_sae
             total_loss = total_loss + weighted_sae_loss
             total_precision = total_precision + precision_sae
             total_log_var = total_log_var + clamped_log_vars['sae']
 
         if self.use_diffusion:
-            precision_diff = torch.exp(clamped_log_vars['diffusion'])
+            precision_diff = torch.exp(-clamped_log_vars['diffusion'])
             weighted_diff_loss = diffusion_loss * precision_diff * self.diffusion_weight
             total_loss = total_loss + weighted_diff_loss
             total_precision = total_precision + precision_diff

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -63,5 +63,39 @@ class TestPredictionBlocks(unittest.TestCase):
         self.assertEqual(patient_representation.shape, (2, embed_dim * 2))
         self.assertEqual(prediction.shape, (2, output_dim))
 
+
+class TestHierarchicalModelVicreg(unittest.TestCase):
+    def test_stage1_uses_vicreg_level2(self):
+        from jepa_models.hierarchical_model import HierarchicalClaimsModel
+        from jepa_utils.config import Config
+
+        config = Config()
+        config.use_diffusion = False
+        config.use_sparse_autoencoder = False
+        config.use_token_prediction_head = False
+        config.use_predictor_head = False
+        config.use_level1 = False
+        config.cpt_rarity_scores = None
+        config.icd_rarity_scores = None
+        config.ttnc_rarity_scores = None
+        config.cpt_vocab_size = 10
+        config.icd_vocab_size = 10
+        config.ttnc_vocab_size = 5
+        config.embedding_dim = 4
+        config.output_dim = config.embedding_dim
+        config.max_cpt_tokens = 3
+        config.max_icd_tokens = 3
+        config.max_claims_len = 4
+
+        model = HierarchicalClaimsModel(config)
+        batch_size = 2
+        cpt_tensor = torch.randint(1, config.cpt_vocab_size, (batch_size, config.max_claims_len, config.max_cpt_tokens))
+        icd_tensor = torch.randint(1, config.icd_vocab_size, (batch_size, config.max_claims_len, config.max_icd_tokens))
+        ttnc_tensor = torch.randint(1, config.ttnc_vocab_size, (batch_size, config.max_claims_len))
+        target = torch.randn(batch_size)
+
+        outputs = model.training_forward(cpt_tensor, icd_tensor, ttnc_tensor, target)
+        self.assertGreater(outputs['vicreg_loss_lvl2'].item(), 0)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- ensure SAE, task, token prediction and diffusion log variance parameters use negative exponent in `calculate_total_loss`
- add test covering VICReg loss calculation in Stage 1

## Testing
- `pytest -q`
