### PR TITLE
Fix VICReg-L2 logging

### DIFF
--- a/jepa_models/hierarchical_model.py
+++ b/jepa_models/hierarchical_model.py
@@ -932,6 +932,21 @@ class HierarchicalClaimsModel(pl.LightningModule):
             diffusion_loss=diffusion_loss,
         )
 
+        # Precision-weighted VICReg-L2 for logging
+        clamped = torch.clamp(self.log_vars['vicreg_lvl2'], min=-5, max=5)
+        precision_vicreg_lvl2 = torch.exp(-clamped)
+        weighted_vicreg_lvl2 = (
+            outputs['vicreg_loss_lvl2'] * precision_vicreg_lvl2 * self.level_2_weight
+        )
+        self.log(
+            "vicreg_lvl2",
+            weighted_vicreg_lvl2,
+            on_step=False,
+            on_epoch=True,
+            prog_bar=True,
+            logger=True,
+        )
+
         # --- Logging ---
         self.log('loss', total_loss, on_step=False, on_epoch=True, prog_bar=True, logger=True)
 


### PR DESCRIPTION
## Summary
- log precision-weighted VICReg-L2 during training

## Testing
- `pytest -q` *(fails: TestPretrainDiffusionFlag.test_pretrain_disabled, test_pretrain_enabled)*