### PR TITLE
Expand Stage 2 training docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,3 +74,71 @@ generator by default.  Disable this by setting `pretrain_diffusion = False` in
 avoid interfering with the shared weights.
 
 Diffusion support has fully replaced the old GAN implementation. Set `use_diffusion = False` if you want to disable claim synthesis.
+## Multi-Stage Training
+
+### Stage 1 – Self-Supervised Representation Pre-Train
+Learn rich patient embeddings using VICReg-L2 and a sparse auto-encoder.
+
+- **Compute**
+  - **VICReg-L2**: predict the next-claim Level-2 embedding from the current context.
+  - **Sparse Auto-Encoder (SAE)**: reconstruct the same Level-2 embedding via a top-K bottleneck.
+- **Trainable modules**
+  - Context & target Level-2 encoders
+  - SAE encoder/decoder & gating network
+- **Frozen**
+  - Token-prediction head
+  - Diffusion model
+- **Key config**
+  ```yaml
+  use_level2_vicreg: true
+  level_2_weight: 1.0
+  use_sparse_autoencoder: true
+  sae_weight: 1.0
+  use_token_prediction_head: false
+  use_diffusion: false
+  current_stage: "stage1"
+  ```
+- **Checkpoint**: save `encoder_only.ckpt` at epoch end.
+
+### Stage 2 – Diffusion-Based Code Generation
+Keep the learned representations fixed and train the generator to emit CPT/ICD/TTNC codes.
+
+- **Compute**
+  - Encoders & SAE perform a forward pass only to supply representations.
+  - `DiffusionModel.sample()` denoises from Gaussian noise to discrete code embeddings.
+  - Optionally a token head can directly output logits.
+- **Trainable modules**
+  - Diffusion model & its projection layers
+  - Token-prediction head (if enabled)
+  - Gating network adapters
+- **Frozen modules & losses**
+  - Context/target encoders and SAE (`requires_grad=False`)
+  - VICReg-L2 and SAE losses disabled (`level_2_weight=0.0`, `sae_weight=0.0`)
+- **Key config**
+  ```yaml
+  use_sparse_autoencoder: true      # compute but don’t train SAE
+  sae_weight: 0.0
+  use_level2_vicreg: false
+  level_2_weight: 0.0
+  use_token_prediction_head: [true|false]
+  use_diffusion: true
+  diffusion_weight: 0.1
+  current_stage: "stage2"
+  freeze_encoder_at_stage2: true
+  ```
+- **Inference**
+  1. Load `encoder_only.ckpt`.
+  2. Call `freeze_encoder(...)`.
+  3. Run `model.predict()` to produce `predictions.csv`.
+
+### Investigation: Why No CPT/ICD Codes in predictions.csv
+If `predictions.csv` is empty, verify the following:
+
+1. **Stage 2 config** – confirm `use_diffusion=true` and `use_token_prediction_head` is set as intended.
+2. **Predict step logic** – dump raw CPT/ICD and TTNC logits during `predict_step` to ensure they exceed your thresholds.
+3. **Threshold & decoding** – check the multi-label threshold or top-K logic, printing selected indices per sample.
+4. **Diffusion sampling** – instrument `DiscreteDiffusionModel.sample()` to log denoising steps and final token IDs.
+5. **Gating network** – log `gating_sae_fraction` each prediction. Force it to zero temporarily to test diffusion only.
+6. **CSV writer** – trace token IDs to file rows and ensure no default empty token is inserted when none are found.
+7. **Quick experiments** – run with token-only (`use_token_prediction_head=true`, `use_diffusion=false`) or diffusion-only to isolate issues.
+

--- a/jepa_models/diffusion.py
+++ b/jepa_models/diffusion.py
@@ -45,6 +45,8 @@ class DiffusionModel(pl.LightningModule):
 
         self.lr = config.lr
 
+        self.debug_generation = getattr(config, 'debug_generation', False)
+
         # Optional conditioning for downstream tasks
         self.condition_dim = condition_dim or getattr(config, 'diffusion_condition_dim', 0)
         if self.condition_dim and self.condition_dim > 0:
@@ -109,6 +111,8 @@ class DiffusionModel(pl.LightningModule):
                 noise = torch.randn_like(x)
                 sigma = torch.sqrt(self.betas[step])
                 x += sigma * noise
+            if self.debug_generation and step % max(self.num_timesteps // 3, 1) == 0:
+                print(f"continuous step {step} x_norm={x.norm():.3f}")
 
         cpt_logits = self.cpt_proj(x[:, :self.embedding_dim])
         icd_logits = self.icd_proj(x[:, self.embedding_dim:2 * self.embedding_dim])
@@ -116,6 +120,10 @@ class DiffusionModel(pl.LightningModule):
         cpt_tokens = torch.argmax(cpt_logits, dim=-1)
         icd_tokens = torch.argmax(icd_logits, dim=-1)
         ttnc_token = torch.argmax(ttnc_logits, dim=-1)
+        if self.debug_generation:
+            print(
+                f"final sample CPT[0]={cpt_tokens[0].item()} ICD[0]={icd_tokens[0].item()} TTNC[0]={ttnc_token[0].item()}"
+            )
         return cpt_tokens, icd_tokens, ttnc_token
 
     def training_step(self, batch, batch_idx):

--- a/jepa_models/discrete_diffusion.py
+++ b/jepa_models/discrete_diffusion.py
@@ -40,6 +40,8 @@ class DiscreteDiffusionModel(pl.LightningModule):
 
         self.lr = config.lr
 
+        self.debug_generation = getattr(config, 'debug_generation', False)
+
         self.condition_dim = condition_dim or getattr(config, "diffusion_condition_dim", 0)
         if self.condition_dim and self.condition_dim > 0:
             self.condition_proj = nn.Linear(self.condition_dim, self.embedding_dim * 3)
@@ -143,9 +145,16 @@ class DiscreteDiffusionModel(pl.LightningModule):
             icd_tokens = torch.argmax(icd_logits, dim=-1)
             ttnc_tokens = torch.argmax(ttnc_logits, dim=-1)
 
+            if self.debug_generation and step % max(self.num_timesteps // 3, 1) == 0:
+                print(f"diffusion step {step}: CPT[0]={cpt_tokens[0].tolist()} ICD[0]={icd_tokens[0].tolist()} TTNC[0]={ttnc_tokens[0].item()}")
+
         # Ensure uniqueness of sampled codes within each claim
         cpt_tokens = self._deduplicate(cpt_tokens)
         icd_tokens = self._deduplicate(icd_tokens)
+        if self.debug_generation:
+            print(
+                f"final sample CPT[0]={cpt_tokens[0].tolist()} ICD[0]={icd_tokens[0].tolist()} TTNC[0]={ttnc_tokens[0].item()}"
+            )
         return cpt_tokens, icd_tokens, ttnc_tokens
 
     def _deduplicate(self, tokens, pad_value=0):

--- a/jepa_models/hierarchical_model.py
+++ b/jepa_models/hierarchical_model.py
@@ -165,12 +165,12 @@ class HierarchicalClaimsModel(pl.LightningModule):
         super(HierarchicalClaimsModel, self).__init__()
         self.automatic_optimization = True
         self.save_hyperparameters()
-        print("Initializing HierarchicalClaimsModel")
-        # Check config values
-        print(f"cpt_vocab_size: {config.cpt_vocab_size}")
-        print(f"icd_vocab_size: {config.icd_vocab_size}")
-        print(f"ttnc_vocab_size: {config.ttnc_vocab_size}")
-        print(f"embedding_dim: {config.embedding_dim}")
+        if getattr(config, 'debug_generation', False):
+            print("Initializing HierarchicalClaimsModel")
+            print(f"cpt_vocab_size: {config.cpt_vocab_size}")
+            print(f"icd_vocab_size: {config.icd_vocab_size}")
+            print(f"ttnc_vocab_size: {config.ttnc_vocab_size}")
+            print(f"embedding_dim: {config.embedding_dim}")
 
         # Configuration parameters
         self.ema_decay = config.ema_decay
@@ -196,6 +196,7 @@ class HierarchicalClaimsModel(pl.LightningModule):
         self.use_diffusion = getattr(config, 'use_diffusion', False)
         self.diffusion_type = getattr(config, 'diffusion_type', 'continuous')
         self.diffusion_weight = getattr(config, 'diffusion_weight', 1.0)
+        self.debug_generation = getattr(config, 'debug_generation', False)
         self.cpt_vocab_size = config.cpt_vocab_size
         self.icd_vocab_size = config.icd_vocab_size
         self.is_stage1_pretrain = getattr(config, 'current_stage', 'stage1') == 'stage1'
@@ -775,6 +776,8 @@ class HierarchicalClaimsModel(pl.LightningModule):
                 sae_contrib = torch.norm(sae_part, dim=-1).mean()
                 patient_contrib = torch.norm(patient_part, dim=-1).mean()
                 gating_sae_fraction = sae_contrib / (sae_contrib + patient_contrib + 1e-8)
+                if self.debug_generation:
+                    print(f"gating_sae_fraction={gating_sae_fraction.item():.3f}")
 
 
                 # ─── Diffusion loss for the last-claim reconstruction ─────────

--- a/jepa_utils/config.py
+++ b/jepa_utils/config.py
@@ -66,6 +66,7 @@ class Config:
     encoder_unfreeze_layers: int = 1
     current_stage: str = "stage1"
     debug_low_threshold: bool = False
+    debug_generation: bool = False
     out_encoder_ckpt: str = "encoder_only.ckpt"
     pretrained_encoder_ckpt: str = "encoder_only.ckpt"
     sae_hidden_dim: int = 256

--- a/jepa_utils/prediction_utils.py
+++ b/jepa_utils/prediction_utils.py
@@ -1,0 +1,28 @@
+from typing import Dict, List
+import torch
+
+
+def decode_predicted_codes(predicted: torch.Tensor, id_to_token: Dict[int, str]) -> List[List[str]]:
+    """Convert predicted token tensor to a list of code strings.
+
+    Supports multi-hot vectors (0/1) or integer token IDs of shape
+    ``[batch, num_tokens]``. Padding token ``0`` is ignored.
+    """
+    predicted = predicted.cpu()
+    results: List[List[str]] = []
+    if predicted.dim() == 2:
+        if predicted.max() > 1:
+            # token IDs from diffusion
+            for row in predicted:
+                codes = [id_to_token.get(int(idx), '<UNK>') for idx in row.tolist() if idx != 0]
+                results.append(codes)
+        else:
+            for row in predicted:
+                indices = (row == 1).nonzero(as_tuple=True)[0].tolist()
+                codes = [id_to_token.get(int(idx), '<UNK>') for idx in indices if idx != 0]
+                results.append(codes)
+    else:
+        for idx in predicted.tolist():
+            codes = [id_to_token.get(int(idx), '<UNK>')]
+            results.append(codes)
+    return results

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -16,6 +16,7 @@ from jepa_models.diffusion import DiffusionModel
 from jepa_utils.tensor_utils import calculate_entropy, adaptive_sampling
 from jepa_utils.metrics import calculate_rmse
 from jepa_utils.config import Config
+from jepa_utils.prediction_utils import decode_predicted_codes
 import copy
 
 
@@ -177,26 +178,21 @@ def main():
                 predicted_icd_codes = outputs['predicted_icd_codes']
                 predicted_ttnc_code = outputs['predicted_ttnc_code']
 
+                decoded_cpt = decode_predicted_codes(
+                    predicted_cpt_codes, config.cpt_id_to_token
+                )
+                decoded_icd = decode_predicted_codes(
+                    predicted_icd_codes, config.icd_id_to_token
+                )
+
                 for i in range(cpt_tensor.size(0)):
-                    # Process predicted CPT codes
-                    if predicted_cpt_codes.dim() == 2:
-                        pred_cpt_idx = (predicted_cpt_codes[i] == 1).nonzero(as_tuple=True)[0].cpu().numpy()
-                        predicted_cpt_codes_list = [config.cpt_id_to_token.get(idx, '<UNK>') for idx in pred_cpt_idx if idx != 0]
-                    else:
-                        pred_cpt_idx = predicted_cpt_codes[i].item()
-                        predicted_cpt_codes_list = [config.cpt_id_to_token.get(pred_cpt_idx, '<UNK>')]
+                    predicted_cpt_codes_list = decoded_cpt[i]
 
                     # Process actual CPT codes (from the last claim)
                     actual_cpt_indices = cpt_tensor[i, -1, :].cpu().numpy()
                     actual_cpt_codes = [config.cpt_id_to_token.get(idx, '<UNK>') for idx in actual_cpt_indices if idx != 0]
 
-                    # Process predicted ICD codes
-                    if predicted_icd_codes.dim() == 2:
-                        pred_icd_idx = (predicted_icd_codes[i] == 1).nonzero(as_tuple=True)[0].cpu().numpy()
-                        predicted_icd_codes_list = [config.icd_id_to_token.get(idx, '<UNK>') for idx in pred_icd_idx if idx != 0]
-                    else:
-                        pred_icd_idx = predicted_icd_codes[i].item()
-                        predicted_icd_codes_list = [config.icd_id_to_token.get(pred_icd_idx, '<UNK>')]
+                    predicted_icd_codes_list = decoded_icd[i]
 
                     # Process actual ICD codes (from the last claim)
                     actual_icd_indices = icd_tensor[i, -1, :].cpu().numpy()

--- a/tests/test_prediction_utils.py
+++ b/tests/test_prediction_utils.py
@@ -1,0 +1,25 @@
+import unittest
+import torch
+from jepa_utils.prediction_utils import decode_predicted_codes
+
+class TestDecodePredictedCodes(unittest.TestCase):
+    def test_decode_multi_hot(self):
+        tensor = torch.tensor([[0,1,0,1]])
+        id_to_token = {0:'<PAD>',1:'A',2:'B',3:'C'}
+        decoded = decode_predicted_codes(tensor, id_to_token)
+        self.assertEqual(decoded, [['A','C']])
+
+    def test_decode_token_ids(self):
+        tensor = torch.tensor([[2,3,0]])
+        id_to_token = {0:'<PAD>',2:'B',3:'C'}
+        decoded = decode_predicted_codes(tensor, id_to_token)
+        self.assertEqual(decoded, [['B','C']])
+
+    def test_decode_single_token(self):
+        tensor = torch.tensor([3])
+        id_to_token = {3:'C'}
+        decoded = decode_predicted_codes(tensor, id_to_token)
+        self.assertEqual(decoded, [['C']])
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- document the multi-stage training flow in the README
- add detailed notes for Stage 2 diffusion training
- include troubleshooting tips when predictions.csv is empty
- decode diffusion IDs correctly when saving predictions
- add optional debugging logs for diffusion sampling

## Testing
- `pytest -q`
