### PR TITLE
Implement diffusion improvements

### DIFF
--- a/jepa_models/discrete_diffusion.py
+++ b/jepa_models/discrete_diffusion.py
@@ -24,6 +24,9 @@ class DiscreteDiffusionModel(pl.LightningModule):
         self.icd_embedding = nn.Embedding(self.icd_vocab_size, self.embedding_dim)
         self.ttnc_embedding = nn.Embedding(self.ttnc_vocab_size, self.embedding_dim)
 
+        self.cpt_threshold = getattr(config, "cpt_threshold", 0.5)
+        self.icd_threshold = getattr(config, "icd_threshold", 0.5)
+
         self.model = nn.Sequential(
             nn.Linear(self.embedding_dim * 3, self.embedding_dim * 6),
             nn.ReLU(),
@@ -52,13 +55,15 @@ class DiscreteDiffusionModel(pl.LightningModule):
         self.max_icd_tokens = config.max_icd_tokens
 
     def q_sample(self, tokens, vocab_size, t):
-        """Perform a single diffusion step on the provided tokens."""
-        # ``t`` has shape [batch_size]. Adapt the beta values to match the
-        # dimensionality of ``tokens`` so broadcasting works for both 1-D and
-        # 2-D token tensors.
+        """Perform a single diffusion step on the provided tokens.
+
+        Padding positions (token==0) are left unchanged to avoid
+        learning dynamics dominated by PAD slots.
+        """
         prob = self.betas[t].view(tokens.size(0), *([1] * (tokens.dim() - 1)))
         noise = torch.randint(0, vocab_size, tokens.shape, device=tokens.device)
         mask = torch.bernoulli(prob.expand_as(tokens)).bool()
+        mask &= tokens != 0
         return torch.where(mask, noise, tokens)
 
     def aggregate_tokens(self, cpt_tokens, icd_tokens, ttnc_tokens):
@@ -94,14 +99,25 @@ class DiscreteDiffusionModel(pl.LightningModule):
         cpt_logits = cpt_logits.view(batch_size, self.max_cpt_tokens, self.cpt_vocab_size)
         icd_logits = icd_logits.view(batch_size, self.max_icd_tokens, self.icd_vocab_size)
 
-        # Flatten to compute cross-entropy across all slots
         loss_cpt = F.cross_entropy(
-            cpt_logits.reshape(-1, self.cpt_vocab_size), cpt_tokens.reshape(-1)
+            cpt_logits.reshape(-1, self.cpt_vocab_size),
+            cpt_tokens.reshape(-1),
+            reduction="none",
         )
         loss_icd = F.cross_entropy(
-            icd_logits.reshape(-1, self.icd_vocab_size), icd_tokens.reshape(-1)
+            icd_logits.reshape(-1, self.icd_vocab_size),
+            icd_tokens.reshape(-1),
+            reduction="none",
         )
-        loss_ttnc = F.cross_entropy(ttnc_logits, ttnc_tokens)
+        loss_ttnc = F.cross_entropy(ttnc_logits, ttnc_tokens, reduction="none")
+
+        cpt_mask = cpt_tokens.reshape(-1) != 0
+        icd_mask = icd_tokens.reshape(-1) != 0
+        ttnc_mask = ttnc_tokens != 0
+
+        loss_cpt = (loss_cpt * cpt_mask).sum() / (cpt_mask.sum() + 1e-8)
+        loss_icd = (loss_icd * icd_mask).sum() / (icd_mask.sum() + 1e-8)
+        loss_ttnc = (loss_ttnc * ttnc_mask).sum() / (ttnc_mask.sum() + 1e-8)
         loss = loss_cpt + loss_icd + loss_ttnc
         return loss
 
@@ -141,20 +157,36 @@ class DiscreteDiffusionModel(pl.LightningModule):
             cpt_logits = cpt_logits.view(batch_size, self.max_cpt_tokens, self.cpt_vocab_size)
             icd_logits = icd_logits.view(batch_size, self.max_icd_tokens, self.icd_vocab_size)
 
-            cpt_tokens = torch.argmax(cpt_logits, dim=-1)
-            icd_tokens = torch.argmax(icd_logits, dim=-1)
-            ttnc_tokens = torch.argmax(ttnc_logits, dim=-1)
+            if step > 0:
+                cpt_tokens = torch.argmax(cpt_logits, dim=-1)
+                icd_tokens = torch.argmax(icd_logits, dim=-1)
+                ttnc_tokens = torch.argmax(ttnc_logits, dim=-1)
 
-            if self.debug_generation and step % max(self.num_timesteps // 3, 1) == 0:
-                print(f"diffusion step {step}: CPT[0]={cpt_tokens[0].tolist()} ICD[0]={icd_tokens[0].tolist()} TTNC[0]={ttnc_tokens[0].item()}")
+                if self.debug_generation and step % max(self.num_timesteps // 3, 1) == 0:
+                    print(
+                        f"diffusion step {step}: CPT[0]={cpt_tokens[0].tolist()} ICD[0]={icd_tokens[0].tolist()} TTNC[0]={ttnc_tokens[0].item()}"
+                    )
+            else:
+                cpt_probs = torch.sigmoid(cpt_logits).max(dim=1).values
+                icd_probs = torch.sigmoid(icd_logits).max(dim=1).values
+                ttnc_probs = torch.softmax(ttnc_logits, dim=-1)
 
-        # Ensure uniqueness of sampled codes within each claim
-        cpt_tokens = self._deduplicate(cpt_tokens)
-        icd_tokens = self._deduplicate(icd_tokens)
-        if self.debug_generation:
-            print(
-                f"final sample CPT[0]={cpt_tokens[0].tolist()} ICD[0]={icd_tokens[0].tolist()} TTNC[0]={ttnc_tokens[0].item()}"
-            )
+                cpt_tokens = (cpt_probs > self.cpt_threshold).long()
+                icd_tokens = (icd_probs > self.icd_threshold).long()
+                ttnc_tokens = torch.argmax(ttnc_probs, dim=-1)
+
+                if self.debug_generation:
+                    print(
+                        f"final stats CPT p[min={cpt_probs.min():.3f} max={cpt_probs.max():.3f} mean={cpt_probs.mean():.3f}]"
+                    )
+                    print(
+                        f"final stats ICD p[min={icd_probs.min():.3f} max={icd_probs.max():.3f} mean={icd_probs.mean():.3f}]"
+                    )
+                    print(f"TTNC softmax[0]={ttnc_probs[0].tolist()}")
+                    print(
+                        f"denoised emb var={h.var().item():.3f} min={h.min().item():.3f} max={h.max().item():.3f}"
+                    )
+
         return cpt_tokens, icd_tokens, ttnc_tokens
 
     def _deduplicate(self, tokens, pad_value=0):

--- a/jepa_models/hierarchical_model.py
+++ b/jepa_models/hierarchical_model.py
@@ -316,6 +316,7 @@ class HierarchicalClaimsModel(pl.LightningModule):
         self.lr = config.lr
         self.adapter_lr = config.adapter_lr
         self.generator_lr = config.generator_lr
+        self.sae_weight = getattr(config, "sae_weight", 1.0)
         self.loss_fn = nn.MSELoss()
         self.log_vars = nn.ParameterDict({
             'vicreg_lvl1': nn.Parameter(torch.tensor(0.0)),
@@ -346,6 +347,23 @@ class HierarchicalClaimsModel(pl.LightningModule):
                     config,
                     condition_dim=config.output_dim,
                 )
+                # Inherit Stage-1 embeddings for CPT/ICD/TTNC
+                self.diffusion_model.cpt_embedding.weight.data.copy_(
+                    self.target_encoder_lvl2.cpt_embedding.weight.data
+                )
+                self.diffusion_model.icd_embedding.weight.data.copy_(
+                    self.target_encoder_lvl2.icd_embedding.weight.data
+                )
+                self.diffusion_model.ttnc_embedding.weight.data.copy_(
+                    self.target_encoder_lvl2.ttnc_embedding.weight.data
+                )
+                requires_grad = getattr(config, "fine_tune_embeddings", False)
+                for p in [
+                    self.diffusion_model.cpt_embedding.weight,
+                    self.diffusion_model.icd_embedding.weight,
+                    self.diffusion_model.ttnc_embedding.weight,
+                ]:
+                    p.requires_grad = requires_grad
             else:
                 self.diffusion_model = DiffusionModel(
                     config,
@@ -359,6 +377,9 @@ class HierarchicalClaimsModel(pl.LightningModule):
             and getattr(config, "freeze_encoder_at_stage2", True)
         ):
             self.freeze_encoder(getattr(config, "encoder_unfreeze_layers", 1))
+            if self.use_sparse_autoencoder:
+                for p in self.sparse_autoencoder.parameters():
+                    p.requires_grad = False
 
     def _unfreeze_last_n(self, module, n_layers):
         """Helper to unfreeze the last ``n_layers`` child modules of ``module``."""
@@ -538,7 +559,7 @@ class HierarchicalClaimsModel(pl.LightningModule):
 
         if self.use_sparse_autoencoder:
             precision_sae = torch.exp(-clamped_log_vars['sae'])
-            weighted_sae_loss = sae_loss * precision_sae
+            weighted_sae_loss = sae_loss * precision_sae * self.sae_weight
             total_loss = total_loss + weighted_sae_loss
             total_precision = total_precision + precision_sae
             total_log_var = total_log_var + clamped_log_vars['sae']

--- a/jepa_utils/config.py
+++ b/jepa_utils/config.py
@@ -61,6 +61,10 @@ class Config:
     diffusion_weight: float = 1.0  # Weight for diffusion loss when joint training
     diffusion_type: str = "discrete"  # continuous | discrete
     diffusion_steps: int = 100
+    cpt_threshold: float = 0.5
+    icd_threshold: float = 0.5
+    fine_tune_embeddings: bool = False
+    sae_weight: float = 1.0
     freeze_transferred_embeddings: bool = False
     freeze_encoder_at_stage2: bool = True
     encoder_unfreeze_layers: int = 1

--- a/tests/test_diffusion.py
+++ b/tests/test_diffusion.py
@@ -37,8 +37,8 @@ class TestDiffusionModel(unittest.TestCase):
         loss = model(cpt_tokens, icd_tokens, ttnc_tokens)
         self.assertTrue(loss.dim() == 0)
         cpt_pred, icd_pred, ttnc_pred = model.sample(2)
-        self.assertEqual(cpt_pred.shape, (2, config.max_cpt_tokens))
-        self.assertEqual(icd_pred.shape, (2, config.max_icd_tokens))
+        self.assertEqual(cpt_pred.shape, (2, config.cpt_vocab_size))
+        self.assertEqual(icd_pred.shape, (2, config.icd_vocab_size))
         self.assertEqual(ttnc_pred.shape, (2,))
 
     def test_conditioned_sample(self):

--- a/tests/test_diffusion_integration.py
+++ b/tests/test_diffusion_integration.py
@@ -63,8 +63,8 @@ class TestDiffusionIntegration(unittest.TestCase):
         ttnc_tensor = torch.randint(1, config.ttnc_vocab_size, (batch_size, config.max_claims_len))
 
         outputs = model.autoregressive_generation(cpt_tensor, icd_tensor, ttnc_tensor)
-        self.assertEqual(outputs['predicted_cpt_codes'].shape, (batch_size, config.max_cpt_tokens))
-        self.assertEqual(outputs['predicted_icd_codes'].shape, (batch_size, config.max_icd_tokens))
+        self.assertEqual(outputs['predicted_cpt_codes'].shape, (batch_size, config.cpt_vocab_size))
+        self.assertEqual(outputs['predicted_icd_codes'].shape, (batch_size, config.icd_vocab_size))
         self.assertEqual(outputs['predicted_ttnc_code'].shape, (batch_size,))
 
     def test_training_step_with_diffusion_loss(self):


### PR DESCRIPTION
## Summary
- configure diffusion thresholds and embedding fine-tuning
- freeze SAE when encoders are frozen and inherit stage‑1 embeddings for discrete diffusion
- mask PAD slots in diffusion loss
- add probability-threshold decoding with debug stats
- adjust tests for new output shapes

## Testing
- `pytest -q`