### PR TITLE
Dynamic loss logging

### DIFF
--- a/jepa_models/hierarchical_model.py
+++ b/jepa_models/hierarchical_model.py
@@ -1003,7 +1003,22 @@ class HierarchicalClaimsModel(pl.LightningModule):
         
         if self.use_predictor_head:
             self.log('task_loss', outputs['task_loss'], on_step=False, on_epoch=True, prog_bar=True, logger=True)
-        
+
+        # Dynamically print active losses for quick inspection
+        active_losses = [("total", total_loss)]
+        if self.level_2_weight > 0:
+            active_losses.append(("vicreg_lvl2", weighted_vicreg_lvl2))
+        if self.use_sparse_autoencoder and self.sae_weight > 0:
+            active_losses.append(("sae", outputs['sae_loss']))
+        if self.use_token_prediction_head:
+            active_losses.append(("token_pred", outputs['token_pred_loss']))
+        if self.use_diffusion and self.diffusion_weight > 0:
+            active_losses.append(("diffusion", diffusion_loss))
+        if self.use_gated_fusion and self.use_sparse_autoencoder:
+            active_losses.append(("gating_frac", outputs['gating_sae_fraction']))
+        log_items = [f"{name}={value.detach().item():.3f}" for name, value in active_losses]
+        print(" | ".join(log_items))
+
         # Update target encoders after each step
         self.update_target_encoders()
         

--- a/tests/test_pretrain_diffusion.py
+++ b/tests/test_pretrain_diffusion.py
@@ -26,6 +26,7 @@ class TestPretrainDiffusionFlag(unittest.TestCase):
         cfg.use_plotting = False
         cfg.representation_pretrain_epochs = 0
         cfg.generator_train_epochs = 1
+        cfg.joint_train_epochs = 0
         mock_config.return_value = cfg
         mock_prepare.return_value = (None, self.loader, None, None, cfg, None)
         mock_exists.return_value = True
@@ -54,6 +55,7 @@ class TestPretrainDiffusionFlag(unittest.TestCase):
         cfg.use_plotting = False
         cfg.representation_pretrain_epochs = 0
         cfg.generator_train_epochs = 1
+        cfg.joint_train_epochs = 0
         mock_config.return_value = cfg
         mock_prepare.return_value = (None, self.loader, None, None, cfg, None)
         mock_exists.return_value = True


### PR DESCRIPTION
## Summary
- add logging string that prints only the enabled losses
- ensure unit tests reflect new multi-stage defaults

## Testing
- `pytest -q`