### PR TITLE
Implement entropy-based threshold shrink

### DIFF
--- a/jepa_models/discrete_diffusion.py
+++ b/jepa_models/discrete_diffusion.py
@@ -2,6 +2,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 import pytorch_lightning as pl
+import math
 
 class DiscreteDiffusionModel(pl.LightningModule):
     """Simplified discrete diffusion model for token generation."""
@@ -24,8 +25,8 @@ class DiscreteDiffusionModel(pl.LightningModule):
         self.icd_embedding = nn.Embedding(self.icd_vocab_size, self.embedding_dim)
         self.ttnc_embedding = nn.Embedding(self.ttnc_vocab_size, self.embedding_dim)
 
-        self.cpt_threshold = getattr(config, "cpt_threshold", 0.5)
-        self.icd_threshold = getattr(config, "icd_threshold", 0.5)
+        self.cpt_threshold = getattr(config, "base_cpt_threshold", 0.5)
+        self.icd_threshold = getattr(config, "base_icd_threshold", 0.5)
 
         self.model = nn.Sequential(
             nn.Linear(self.embedding_dim * 3, self.embedding_dim * 6),
@@ -171,8 +172,27 @@ class DiscreteDiffusionModel(pl.LightningModule):
                 icd_probs = torch.sigmoid(icd_logits).max(dim=1).values
                 ttnc_probs = torch.softmax(ttnc_logits, dim=-1)
 
-                cpt_tokens = (cpt_probs > self.cpt_threshold).long()
-                icd_tokens = (icd_probs > self.icd_threshold).long()
+                cpt_entropy = -torch.sum(
+                    cpt_probs.clamp(1e-8, 1 - 1e-8)
+                    * torch.log(cpt_probs.clamp(1e-8, 1 - 1e-8)),
+                    dim=1,
+                )
+                icd_entropy = -torch.sum(
+                    icd_probs.clamp(1e-8, 1 - 1e-8)
+                    * torch.log(icd_probs.clamp(1e-8, 1 - 1e-8)),
+                    dim=1,
+                )
+                cpt_norm = cpt_entropy / math.log(cpt_probs.size(-1))
+                icd_norm = icd_entropy / math.log(icd_probs.size(-1))
+                cpt_thresh = (self.cpt_threshold * (1.0 - cpt_norm)).clamp(min=0.1)
+                icd_thresh = (self.icd_threshold * (1.0 - icd_norm)).clamp(min=0.1)
+
+                cpt_tokens = (cpt_probs > cpt_thresh.unsqueeze(-1)).long()
+                icd_tokens = (icd_probs > icd_thresh.unsqueeze(-1)).long()
+                self.log("avg_cpt_entropy", cpt_entropy.mean(), on_step=False, on_epoch=True)
+                self.log("avg_cpt_threshold", cpt_thresh.mean(), on_step=False, on_epoch=True)
+                self.log("avg_icd_entropy", icd_entropy.mean(), on_step=False, on_epoch=True)
+                self.log("avg_icd_threshold", icd_thresh.mean(), on_step=False, on_epoch=True)
                 ttnc_tokens = torch.argmax(ttnc_probs, dim=-1)
 
                 if self.debug_generation:

--- a/jepa_models/hierarchical_model.py
+++ b/jepa_models/hierarchical_model.py
@@ -5,6 +5,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 import pytorch_lightning as pl
 import numpy as np
+import math
 from jepa_models.encoders import Level1Encoder, Level2Encoder
 from jepa_models.prediction_blocks import Level1PredictionBlock, Level2PredictionBlock, LogitsGenerator
 from jepa_models.diffusion import DiffusionModel
@@ -200,6 +201,10 @@ class HierarchicalClaimsModel(pl.LightningModule):
         self.cpt_vocab_size = config.cpt_vocab_size
         self.icd_vocab_size = config.icd_vocab_size
         self.is_stage1_pretrain = getattr(config, 'current_stage', 'stage1') == 'stage1'
+
+        self.cpt_base_threshold = getattr(config, 'base_cpt_threshold', getattr(config, 'cpt_threshold', 0.5))
+        self.icd_base_threshold = getattr(config, 'base_icd_threshold', getattr(config, 'icd_threshold', 0.5))
+        self.debug_low_threshold = getattr(config, 'debug_low_threshold', False)
 
         # Accumulators for patient representations and targets
         # Used for one-shot cross-validation at epoch end
@@ -893,18 +898,29 @@ class HierarchicalClaimsModel(pl.LightningModule):
         cpt_probs = torch.sigmoid(cpt_logits)
         icd_probs = torch.sigmoid(icd_logits)
 
-        # Calculate entropy of the CPT and ICD probabilities
+        # Calculate normalized entropy and derive per-example thresholds
         cpt_entropy = calculate_entropy(cpt_probs)
         icd_entropy = calculate_entropy(icd_probs)
+        cpt_norm_entropy = cpt_entropy / math.log(cpt_probs.size(-1))
+        icd_norm_entropy = icd_entropy / math.log(icd_probs.size(-1))
 
-       # Adjust threshold based on entropy (lower threshold where entropy is lower)
-        # You can fine-tune this logic as needed
-        dynamic_cpt_threshold = self.threshold - self.lambda_entropy * (1 - cpt_entropy / torch.log(torch.tensor(cpt_probs.size(-1))))
-        dynamic_icd_threshold = self.threshold - self.lambda_entropy * (1 - icd_entropy / torch.log(torch.tensor(icd_probs.size(-1))))
+        if self.debug_low_threshold:
+            dynamic_cpt_threshold = self.threshold
+            dynamic_icd_threshold = self.threshold
+        else:
+            shrink_cpt = 1.0 - cpt_norm_entropy
+            shrink_icd = 1.0 - icd_norm_entropy
+            dynamic_cpt_threshold = self.cpt_base_threshold * shrink_cpt
+            dynamic_icd_threshold = self.icd_base_threshold * shrink_icd
+            min_thresh = 0.1
+            dynamic_cpt_threshold = dynamic_cpt_threshold.clamp(min=min_thresh)
+            dynamic_icd_threshold = dynamic_icd_threshold.clamp(min=min_thresh)
 
-        # Clamp thresholds to ensure they remain in a valid range
-        dynamic_cpt_threshold = dynamic_cpt_threshold.clamp(min=0.01, max=0.9)
-        dynamic_icd_threshold = dynamic_icd_threshold.clamp(min=0.01, max=0.9)
+        # Log average entropy and threshold for monitoring
+        self.log("avg_cpt_entropy", cpt_entropy.mean(), on_step=False, on_epoch=True)
+        self.log("avg_cpt_threshold", dynamic_cpt_threshold.mean(), on_step=False, on_epoch=True)
+        self.log("avg_icd_entropy", icd_entropy.mean(), on_step=False, on_epoch=True)
+        self.log("avg_icd_threshold", dynamic_icd_threshold.mean(), on_step=False, on_epoch=True)
 
         # Apply dynamic threshold to select codes
         cpt_predicted = (cpt_probs > dynamic_cpt_threshold.unsqueeze(-1)).long()

--- a/jepa_utils/config.py
+++ b/jepa_utils/config.py
@@ -61,8 +61,8 @@ class Config:
     diffusion_weight: float = 1.0  # Weight for diffusion loss when joint training
     diffusion_type: str = "discrete"  # continuous | discrete
     diffusion_steps: int = 100
-    cpt_threshold: float = 0.5
-    icd_threshold: float = 0.5
+    base_cpt_threshold: float = 0.5
+    base_icd_threshold: float = 0.5
     fine_tune_embeddings: bool = False
     sae_weight: float = 1.0
     freeze_transferred_embeddings: bool = False

--- a/jepa_utils/tensor_utils.py
+++ b/jepa_utils/tensor_utils.py
@@ -1,6 +1,7 @@
 # utils/tensor_utils.py
 import torch
 import random
+import math
 
 def masked_mean(tensor, mask, dim):
     """
@@ -53,12 +54,18 @@ def masked_variance(tensor, mask, dim):
     return variance
 
 def calculate_entropy(probs):
-    # probs: [batch_size, vocab_size]
-    # Add a small epsilon to prevent log(0)
-    epsilon = 1e-12
-    log_probs = torch.log(probs + epsilon)
-    entropy = -torch.sum(probs * log_probs, dim=-1)  # Shape: [batch_size]
+    """Compute the Shannon entropy for a probability distribution."""
+    # Clamp to avoid log(0)
+    p = probs.clamp(min=1e-8, max=1 - 1e-8)
+    log_p = torch.log(p)
+    entropy = -torch.sum(p * log_p, dim=-1)
     return entropy
+
+def normalized_entropy(probs):
+    """Entropy normalised by the maximum possible entropy for the vocabulary."""
+    entropy = calculate_entropy(probs)
+    vocab_size = probs.size(-1)
+    return entropy / math.log(vocab_size)
 
 def adaptive_sampling(probs, entropy, base_temp=1.0, base_top_p=0.9, entropy_adjustment_factor=0.5):
     random.seed()


### PR DESCRIPTION
## Summary
- expose `base_cpt_threshold` and `base_icd_threshold` in `Config`
- add entropy utilities and compute normalised entropy
- derive dynamic thresholds in `HierarchicalClaimsModel`
- adapt discrete diffusion sampler to shrink thresholds by entropy
- log average entropies and thresholds

## Testing
- `pytest -q`