### PR TITLE
Improve diffusion logging

### DIFF
--- a/jepa_models/discrete_diffusion.py
+++ b/jepa_models/discrete_diffusion.py
@@ -122,6 +122,8 @@ class DiscreteDiffusionModel(pl.LightningModule):
         loss_icd = (loss_icd * icd_mask).sum() / (icd_mask.sum() + 1e-8)
         loss_ttnc = (loss_ttnc * ttnc_mask).sum() / (ttnc_mask.sum() + 1e-8)
         loss = loss_cpt + loss_icd + loss_ttnc
+        if self.debug_generation and t.numel() == 1:
+            print(f"t={t.item()}  loss_mean={loss.item():.4f}")
         return loss
 
     def forward(self, cpt_tokens, icd_tokens, ttnc_tokens, condition=None):

--- a/jepa_models/hierarchical_model.py
+++ b/jepa_models/hierarchical_model.py
@@ -1199,6 +1199,11 @@ class HierarchicalClaimsModel(pl.LightningModule):
         for name, param in active_logvars.items():
             self.log(f"logvar_{name}", param.item(), prog_bar=True, logger=True)
 
+        if self.use_diffusion and self.diffusion_weight > 0:
+            clamped = torch.clamp(self.log_vars['diffusion'], min=-5, max=5)
+            lr_mult = torch.exp(-clamped)
+            self.log("diff_lr_mult", lr_mult.item(), prog_bar=True, logger=True)
+
         self.repr_accumulator.clear()
         self.target_accumulator.clear()
 

--- a/scripts/sanity_diffusion.py
+++ b/scripts/sanity_diffusion.py
@@ -1,0 +1,30 @@
+import torch
+from jepa_utils.config import Config
+from jepa_models.discrete_diffusion import DiscreteDiffusionModel
+
+
+def main():
+    cfg = Config()
+    cfg.cpt_vocab_size = 10
+    cfg.icd_vocab_size = 10
+    cfg.ttnc_vocab_size = 5
+    cfg.embedding_dim = 8
+    cfg.max_cpt_tokens = 2
+    cfg.max_icd_tokens = 2
+    cfg.diffusion_steps = 5
+    model = DiscreteDiffusionModel(cfg)
+
+    optimizer = torch.optim.Adam(model.parameters(), lr=1e-3)
+    for step in range(5):
+        cpt = torch.randint(0, cfg.cpt_vocab_size, (4, cfg.max_cpt_tokens))
+        icd = torch.randint(0, cfg.icd_vocab_size, (4, cfg.max_icd_tokens))
+        ttnc = torch.randint(0, cfg.ttnc_vocab_size, (4,))
+        loss = model.p_losses(cpt, icd, ttnc, torch.zeros(4, dtype=torch.long))
+        optimizer.zero_grad()
+        loss.backward()
+        optimizer.step()
+        print(f"step {step} loss {loss.item():.4f}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- log diffusion LR multiplier as `diff_lr_mult`
- show per-timestep loss when `debug_generation` is on
- add `sanity_diffusion.py` helper to test diffusion training loop

## Testing
- `pytest -q`