### PR TITLE
Introduce ClaimD3PM scaffolding

### DIFF
--- a/eval/diffusion_fidelity.py
+++ b/eval/diffusion_fidelity.py
@@ -1,0 +1,16 @@
+"""Evaluate fidelity of synthetic claims using KS/JSD metrics."""
+
+import numpy as np
+from scipy.stats import ks_2samp, entropy
+
+
+def diffusion_fidelity(real, synthetic):
+    real = np.asarray(real)
+    synth = np.asarray(synthetic)
+    ks = ks_2samp(real.ravel(), synth.ravel()).statistic
+    p_real = np.bincount(real.ravel()) + 1
+    p_synth = np.bincount(synth.ravel()) + 1
+    p_real = p_real / p_real.sum()
+    p_synth = p_synth / p_synth.sum()
+    jsd = entropy((p_real + p_synth) / 2, qk=p_real) / 2 + entropy((p_real + p_synth) / 2, qk=p_synth) / 2
+    return {"ks": ks, "jsd": jsd}

--- a/jepa_models/diffusion_models/claim_d3pm.py
+++ b/jepa_models/diffusion_models/claim_d3pm.py
@@ -1,0 +1,73 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import pytorch_lightning as pl
+from torch.distributions.categorical import Categorical
+
+class ClaimD3PM(pl.LightningModule):
+    """Discrete diffusion model for single claim generation."""
+
+    def __init__(self, config, vocab_size, condition_dim):
+        super().__init__()
+        self.save_hyperparameters(ignore=["config"])
+        self.config = config
+        self.vocab_size = vocab_size
+        self.condition_dim = condition_dim
+        self.num_timesteps = getattr(config, "diffusion_steps", 100)
+        self.guidance_scale = getattr(config, "guidance_scale", 4.0)
+
+        self.log_q = nn.Parameter(torch.zeros(self.num_timesteps, vocab_size, vocab_size))
+
+        self.token_embed = nn.Embedding(vocab_size, config.embedding_dim)
+        self.time_embed = nn.Embedding(self.num_timesteps, config.embedding_dim)
+        encoder_layer = nn.TransformerEncoderLayer(
+            d_model=config.embedding_dim,
+            nhead=4,
+            dim_feedforward=config.embedding_dim * 4,
+            dropout=0.0,
+        )
+        self.denoiser = nn.TransformerEncoder(encoder_layer, num_layers=4)
+        self.film_fc = nn.Linear(condition_dim, config.embedding_dim * 2)
+        self.output_proj = nn.Linear(config.embedding_dim, vocab_size)
+        self.lr = getattr(config, "lr", 1e-3)
+
+    def q_sample(self, x0, t):
+        log_probs = self.log_q[t]
+        dist = Categorical(logits=log_probs[x0])
+        return dist.sample()
+
+    def denoise(self, x_t, t, condition=None):
+        emb = self.token_embed(x_t) + self.time_embed(t)
+        if condition is not None:
+            gamma, beta = self.film_fc(condition).chunk(2, dim=-1)
+            emb = emb * (1 + gamma.unsqueeze(1)) + beta.unsqueeze(1)
+        h = self.denoiser(emb)
+        return self.output_proj(h)
+
+    def p_losses(self, x0, t, condition):
+        x_t = self.q_sample(x0, t)
+        logits = self.denoise(x_t, t, condition)
+        loss = F.cross_entropy(logits.view(-1, self.vocab_size), x0.view(-1))
+        return loss
+
+    def forward(self, tokens, condition=None):
+        b = tokens.size(0)
+        t = torch.randint(0, self.num_timesteps, (b,), device=tokens.device)
+        loss = self.p_losses(tokens, t, condition)
+        self.log("diffusion_ce", loss)
+        return loss
+
+    @torch.no_grad()
+    def generate_claim(self, condition, seq_len):
+        device = self.token_embed.weight.device
+        x = torch.randint(0, self.vocab_size, (condition.size(0), seq_len), device=device)
+        for step in reversed(range(self.num_timesteps)):
+            t = torch.full((condition.size(0),), step, dtype=torch.long, device=device)
+            uncond = self.denoise(x, t, None)
+            cond = self.denoise(x, t, condition)
+            logits = uncond + self.guidance_scale * (cond - uncond)
+            x = Categorical(logits=logits).sample()
+        return x
+
+    def configure_optimizers(self):
+        return torch.optim.Adam(self.parameters(), lr=self.lr)

--- a/jepa_utils/config.py
+++ b/jepa_utils/config.py
@@ -57,10 +57,12 @@ class Config:
     # training the main hierarchical model. Kept ``True`` for backwards
     # compatibility.
     pretrain_diffusion: bool = False
-    pretrain_diffusion_epochs: int = 0
+    pretrain_diffusion_epochs: int = 20
     diffusion_weight: float = 1.0  # Weight for diffusion loss when joint training
     diffusion_type: str = "discrete"  # continuous | discrete
     diffusion_steps: int = 100
+    guidance_scale: float = 4.0
+    freeze_denoiser_core: bool = False
     cpt_prob_agg: str = "max"  # max | mean | sum
     ttnc_temperature: float = 1.0
     base_cpt_threshold: float = 0.5

--- a/scripts/generate_claims.py
+++ b/scripts/generate_claims.py
@@ -1,0 +1,22 @@
+"""CLI utility to sample claims from a trained ClaimD3PM model."""
+
+import torch
+import argparse
+from jepa_models.diffusion_models.claim_d3pm import ClaimD3PM
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("checkpoint", help="path to trained checkpoint")
+    parser.add_argument("--num", type=int, default=10)
+    args = parser.parse_args()
+
+    model = ClaimD3PM.load_from_checkpoint(args.checkpoint)
+    model.eval()
+    condition = torch.zeros(args.num, model.condition_dim, device=model.device)
+    samples = model.generate_claim(condition, seq_len=5)
+    print(samples.tolist())
+
+
+if __name__ == "__main__":
+    main()

--- a/trainers/diffusion_trainer.py
+++ b/trainers/diffusion_trainer.py
@@ -1,0 +1,20 @@
+"""Utility to pretrain ClaimD3PM."""
+
+import pytorch_lightning as pl
+from torch.utils.data import DataLoader
+from jepa_models.diffusion_models.claim_d3pm import ClaimD3PM
+
+
+def run_pretrain(cfg, dataloader: DataLoader):
+    model = ClaimD3PM(
+        cfg,
+        cfg.cpt_vocab_size + cfg.icd_vocab_size + cfg.ttnc_vocab_size + 3,
+        cfg.output_dim,
+    )
+    trainer = pl.Trainer(
+        max_epochs=getattr(cfg, "pretrain_diffusion_epochs", 20),
+        accelerator="gpu" if pl.utilities.device_parser.num_cuda_devices() > 0 else "cpu",
+        log_every_n_steps=10,
+    )
+    trainer.fit(model, dataloader)
+    return model, trainer


### PR DESCRIPTION
## Summary
- add ClaimD3PM discrete diffusion prototype
- expose simple diffusion trainer helper
- utility script for claim generation
- add fidelity metrics helper
- extend config with diffusion parameters

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683c5dbb37f8832ca8e4c8e53e5adc0d