### PR TITLE
Fix diffusion pretrain misconfiguration

### DIFF
--- a/diffusion_models/claim_d3pm.py
+++ b/diffusion_models/claim_d3pm.py
@@ -71,3 +71,14 @@ class ClaimD3PM(pl.LightningModule):
 
     def configure_optimizers(self):
         return torch.optim.Adam(self.parameters(), lr=self.lr)
+
+    def training_step(self, batch, batch_idx):
+        """Standard Lightning training step for diffusion pretraining."""
+        cpt, icd, ttnc, _ = batch
+        cpt_tokens = cpt[:, -1, :]
+        icd_tokens = icd[:, -1, :]
+        ttnc_tokens = ttnc[:, -1]
+        tokens = torch.cat([cpt_tokens, icd_tokens, ttnc_tokens.unsqueeze(1)], dim=1)
+        loss = self.forward(tokens)
+        self.log("loss", loss, on_step=True, on_epoch=True, prog_bar=True)
+        return loss


### PR DESCRIPTION
## Summary
- implement `training_step` in `ClaimD3PM`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_683c78662218832c8e4d4acd685f9c16