### PR TITLE
Fix transformer shapes in ClaimD3PM

### DIFF
--- a/diffusion_models/claim_d3pm.py
+++ b/diffusion_models/claim_d3pm.py
@@ -29,6 +29,7 @@ class ClaimD3PM(pl.LightningModule):
             nhead=4,
             dim_feedforward=config.embedding_dim * 4,
             dropout=0.0,
+            batch_first=True,
         )
         self.denoiser = nn.TransformerEncoder(encoder_layer, num_layers=4)
         self.film_fc = nn.Linear(condition_dim, config.embedding_dim * 2)
@@ -50,7 +51,10 @@ class ClaimD3PM(pl.LightningModule):
         return torch.where(keep_mask, x0, noise)
 
     def denoise(self, x_t, t, condition=None):
-        emb = self.token_embed(x_t) + self.time_embed(t)
+        token_emb = self.token_embed(x_t)
+        time_emb = self.time_embed(t).unsqueeze(1)
+        time_emb = time_emb.expand(-1, x_t.size(1), -1)
+        emb = token_emb + time_emb
         if condition is not None:
             gamma, beta = self.film_fc(condition).chunk(2, dim=-1)
             emb = emb * (1 + gamma.unsqueeze(1)) + beta.unsqueeze(1)

--- a/tests/test_diffusion.py
+++ b/tests/test_diffusion.py
@@ -22,6 +22,19 @@ class TestClaimD3PM(unittest.TestCase):
             samples = model.generate_claim(condition, seq_len=5)
         self.assertEqual(samples.shape, (2, 5))
 
+    def test_forward_loss_is_finite(self):
+        cfg = Config()
+        cfg.cpt_vocab_size = 8
+        cfg.icd_vocab_size = 8
+        cfg.ttnc_vocab_size = 5
+        cfg.embedding_dim = 4
+        cfg.diffusion_steps = 5
+        vocab_size = cfg.cpt_vocab_size + cfg.icd_vocab_size + cfg.ttnc_vocab_size + 3
+        model = ClaimD3PM(cfg, vocab_size, condition_dim=cfg.embedding_dim)
+        tokens = torch.randint(0, vocab_size, (2, 11))
+        loss = model(tokens)
+        self.assertTrue(torch.isfinite(loss))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- broadcast timestep embeddings across the sequence dimension
- set `batch_first=True` on the transformer encoder
- add regression test ensuring ClaimD3PM forward pass returns a finite loss

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683c903a4704832c9b33f689431fbf1f