### PR TITLE
Fix generative save on stage1

### DIFF
--- a/diffusion_models/claim_d3pm.py
+++ b/diffusion_models/claim_d3pm.py
@@ -71,3 +71,14 @@ class ClaimD3PM(pl.LightningModule):
 
     def configure_optimizers(self):
         return torch.optim.Adam(self.parameters(), lr=self.lr)
+
+    def training_step(self, batch, batch_idx):
+        """Standard Lightning training step for diffusion pretraining."""
+        cpt, icd, ttnc, _ = batch
+        cpt_tokens = cpt[:, -1, :]
+        icd_tokens = icd[:, -1, :]
+        ttnc_tokens = ttnc[:, -1]
+        tokens = torch.cat([cpt_tokens, icd_tokens, ttnc_tokens.unsqueeze(1)], dim=1)
+        loss = self.forward(tokens)
+        self.log("loss", loss, on_step=True, on_epoch=True, prog_bar=True)
+        return loss

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -148,7 +148,8 @@ def main():
     # generator is enabled. This allows saving predictions when the model
     # relies solely on diffusion-based generation.
     if config.use_generative_save and (
-        config.use_token_prediction_head or config.use_diffusion
+        getattr(model, "use_token_prediction_head", False)
+        or getattr(model, "use_diffusion", False)
     ):
         device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
         model = model.to(device)


### PR DESCRIPTION
## Summary
- don't call generative prediction after stage 1 when diffusion/token head disabled

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'models')*

------
https://chatgpt.com/codex/tasks/task_e_683c78662218832c8e4d4acd685f9c16