### PR TITLE
Fix diffusion logging and CLI defaults

### DIFF
--- a/diffusion_models/claim_d3pm.py
+++ b/diffusion_models/claim_d3pm.py
@@ -71,7 +71,6 @@ class ClaimD3PM(pl.LightningModule):
         b = tokens.size(0)
         t = torch.randint(0, self.num_timesteps, (b,), device=tokens.device)
         loss = self.p_losses(tokens, t, condition)
-        self.log("diffusion_ce", loss)
         return loss
 
     @torch.no_grad()
@@ -98,4 +97,6 @@ class ClaimD3PM(pl.LightningModule):
         tokens = torch.cat([cpt_tokens, icd_tokens, ttnc_tokens.unsqueeze(1)], dim=1)
         loss = self.forward(tokens)
         self.log("loss", loss, on_step=True, on_epoch=True, prog_bar=True)
+        # Explicitly log diffusion cross-entropy for monitoring
+        self.log("diffusion_ce", loss, on_step=True, on_epoch=True, prog_bar=True)
         return loss

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -22,8 +22,10 @@ import copy
 
 
 def main(argv=None):
+    if argv is None:
+        argv = []
     parser = argparse.ArgumentParser(description="JEPA training")
-    parser.add_argument("--phase", choices=["pretrain", "joint"], default="pretrain")
+    parser.add_argument("--phase", choices=["pretrain", "joint"], default=None)
     parser.add_argument("--resume", type=str, default=None, help="checkpoint to resume for joint phase")
     args = parser.parse_args(argv)
 
@@ -79,6 +81,21 @@ def main(argv=None):
         trainer.fit(model, train_dataloader)
         trainer.save_checkpoint("joint.ckpt")
         return
+
+    if args.phase is None and config.use_diffusion and getattr(config, "pretrain_diffusion", True):
+        vocab_size = (
+            config.cpt_vocab_size + config.icd_vocab_size + config.ttnc_vocab_size + 3
+        )
+        diffusion_model = ClaimD3PM(config, vocab_size, config.output_dim)
+        diffusion_trainer = pl.Trainer(
+            max_epochs=getattr(config, "pretrain_diffusion_epochs", config.epochs),
+            accelerator='gpu',
+            logger=pl.loggers.TensorBoardLogger("tb_logs", name="diffusion"),
+            callbacks=[RichProgressBar(refresh_rate=1)],
+            log_every_n_steps=3
+        )
+        diffusion_trainer.fit(diffusion_model, train_dataloader)
+        diffusion_trainer.save_checkpoint("diffusion_only.ckpt")
 
     def train_stage(cfg, stage_name, ckpt_path=None, freeze=False):
         cfg.current_stage = stage_name
@@ -322,4 +339,5 @@ def main(argv=None):
 
 
 if __name__ == '__main__':
-    main()
+    import sys
+    main(sys.argv[1:])


### PR DESCRIPTION
## Summary
- avoid calling `self.log` inside diffusion forward pass
- log diffusion cross entropy in `training_step`
- handle empty `argv` for CLI and default to full training schedule
- call `main(sys.argv[1:])` when running as script
- support automatic diffusion pretrain when no phase specified

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683cb2971a2c832cb922a59c3cc6576c