### PR TITLE
Fix generate_claims loader

### DIFF
--- a/scripts/generate_claims.py
+++ b/scripts/generate_claims.py
@@ -2,16 +2,38 @@
 
 import torch
 import argparse
-from models.diffusion import ClaimD3PM
+from diffusion_models import ClaimD3PM
+from jepa_utils.config import Config
 
 
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("checkpoint", help="path to trained checkpoint")
     parser.add_argument("--num", type=int, default=10)
+    parser.add_argument("--vocab-size", type=int, default=None,
+                        help="Model vocabulary size if not stored in checkpoint")
+    parser.add_argument("--condition-dim", type=int, default=None,
+                        help="Conditioning dimension if not stored in checkpoint")
     args = parser.parse_args()
 
-    model = ClaimD3PM.load_from_checkpoint(args.checkpoint)
+    try:
+        model = ClaimD3PM.load_from_checkpoint(args.checkpoint)
+    except TypeError:
+        ckpt = torch.load(args.checkpoint, map_location="cpu")
+        hparams = ckpt.get("hyper_parameters", {})
+        config_dict = hparams.get("config", {})
+        config = Config()
+        if isinstance(config_dict, dict):
+            for k, v in config_dict.items():
+                setattr(config, k, v)
+        vocab_size = args.vocab_size if args.vocab_size is not None else hparams.get("vocab_size")
+        condition_dim = args.condition_dim if args.condition_dim is not None else hparams.get("condition_dim")
+        model = ClaimD3PM.load_from_checkpoint(
+            args.checkpoint,
+            config=config,
+            vocab_size=vocab_size,
+            condition_dim=condition_dim,
+        )
     model.eval()
     condition = torch.zeros(args.num, model.condition_dim, device=model.device)
     samples = model.generate_claim(condition, seq_len=5)


### PR DESCRIPTION
## Summary
- update imports in `generate_claims.py`
- handle checkpoints missing hyperparams by loading them manually
- expose vocab size and condition dim via CLI args

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683cb821f7f0832c8d6396223497bc17