### PR TITLE
Handle checkpoints with missing vocab sizes

### DIFF
--- a/jepa_models/prediction_blocks.py
+++ b/jepa_models/prediction_blocks.py
@@ -101,6 +101,12 @@ class Level2PredictionBlock(nn.Module):
         super(Level2PredictionBlock, self).__init__()
 
         self.padding_idx = padding_idx
+        # Older checkpoints may lack vocabulary sizes which can result in
+        # zero-sized embeddings and linear layers. Guard against that by
+        # ensuring each vocabulary has at least one entry.
+        cpt_vocab_size = max(1, cpt_vocab_size)
+        icd_vocab_size = max(1, icd_vocab_size)
+        ttnc_vocab_size = max(1, ttnc_vocab_size)
         # Positional Embedding Layer
         self.position_embedding = nn.Embedding(max_seq_length, embed_dim)
         self.rnn_type = rnn_type
@@ -258,11 +264,11 @@ class LogitsGenerator(nn.Module):
         self.fc1 = nn.Linear(config.embedding_dim, config.hidden_dim)
         self.relu = nn.ReLU()
         self.dropout = nn.Dropout(config.dropout)
-        
+
         # Separate output layers for each token type
-        self.fc_cpt = nn.Linear(config.hidden_dim, config.cpt_vocab_size)
-        self.fc_icd = nn.Linear(config.hidden_dim, config.icd_vocab_size)
-        self.fc_ttnc = nn.Linear(config.hidden_dim, config.ttnc_vocab_size)
+        self.fc_cpt = nn.Linear(config.hidden_dim, max(1, config.cpt_vocab_size))
+        self.fc_icd = nn.Linear(config.hidden_dim, max(1, config.icd_vocab_size))
+        self.fc_ttnc = nn.Linear(config.hidden_dim, max(1, config.ttnc_vocab_size))
     
     def forward(self, combined_representation):
         """

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -63,6 +63,24 @@ class TestPredictionBlocks(unittest.TestCase):
         self.assertEqual(patient_representation.shape, (2, embed_dim * 2))
         self.assertEqual(prediction.shape, (2, output_dim))
 
+    def test_level2_prediction_block_zero_vocab(self):
+        """Ensure initialization succeeds when vocab sizes are zero."""
+        embed_dim = 8
+        output_dim = 4
+        block = Level2PredictionBlock(
+            embed_dim,
+            output_dim,
+            cpt_vocab_size=0,
+            icd_vocab_size=0,
+            ttnc_vocab_size=0,
+            max_seq_length=10,
+        )
+        context_embeddings = torch.randn(1, 3, embed_dim)
+        ttnc_tokens = torch.zeros(1, 3, dtype=torch.long)
+        patient_rep, pred = block(context_embeddings, ttnc_tokens)
+        self.assertEqual(patient_rep.shape, (1, embed_dim))
+        self.assertEqual(pred.shape, (1, output_dim))
+
 
 class TestHierarchicalModelVicreg(unittest.TestCase):
     def test_stage1_uses_vicreg_level2(self):


### PR DESCRIPTION
## Summary
- guard Level2PredictionBlock/LogitsGenerator against zero vocab sizes
- test zero-sized vocabulary initialization

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683cc6751180832c93dc11b5c3bc01c8