### PR TITLE
Fix generate_claims config loading

### DIFF
--- a/scripts/generate_claims.py
+++ b/scripts/generate_claims.py
@@ -32,6 +32,36 @@ def main():
     if isinstance(config_dict, dict):
         for k, v in config_dict.items():
             setattr(config, k, v)
+    else:
+        # ``config`` may be stored as a dataclass instance. Populate the
+        # default ``Config`` with any attributes found in the checkpoint
+        # object to maintain backwards compatibility.
+        for k in getattr(config_dict, "__dict__", {}):
+            setattr(config, k, getattr(config_dict, k))
+
+    state_dict = ckpt.get("state_dict", {})
+
+    def _update_size(attr, keys):
+        current = getattr(config, attr, 0)
+        if current in (0, 1):
+            for key in keys:
+                tensor = state_dict.get(key)
+                if isinstance(tensor, torch.Tensor):
+                    setattr(config, attr, tensor.size(0))
+                    break
+
+    _update_size("cpt_vocab_size", [
+        "context_encoder_lvl2.cpt_embedding.weight",
+        "target_encoder_lvl2.cpt_embedding.weight",
+    ])
+    _update_size("icd_vocab_size", [
+        "context_encoder_lvl2.icd_embedding.weight",
+        "target_encoder_lvl2.icd_embedding.weight",
+    ])
+    _update_size("ttnc_vocab_size", [
+        "context_encoder_lvl2.ttnc_embedding.weight",
+        "target_encoder_lvl2.ttnc_embedding.weight",
+    ])
 
     try:
         model = HierarchicalClaimsModel.load_from_checkpoint(

--- a/tests/test_generate_claims.py
+++ b/tests/test_generate_claims.py
@@ -1,0 +1,53 @@
+import os
+import sys
+import tempfile
+import torch
+import types
+import unittest
+from unittest import mock
+
+import scripts.generate_claims as gen
+from jepa_utils.config import Config
+from jepa_models.hierarchical_model import HierarchicalClaimsModel
+
+class TestGenerateClaimsLoad(unittest.TestCase):
+    def test_load_vocab_from_checkpoint(self):
+        # Build a minimal state_dict with embedding weights
+        state_dict = {
+            'context_encoder_lvl2.cpt_embedding.weight': torch.randn(5, 4),
+            'context_encoder_lvl2.icd_embedding.weight': torch.randn(6, 4),
+            'context_encoder_lvl2.ttnc_embedding.weight': torch.randn(3, 4),
+        }
+        ckpt = {'state_dict': state_dict, 'hyper_parameters': {'config': {}}}
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, 'model.ckpt')
+            torch.save(ckpt, path)
+
+            captured = {}
+            def fake_load(path_arg, config, strict=False):
+                captured['config'] = config
+                class Dummy:
+                    def __init__(self):
+                        self.config = config
+                        self.diffusion_model = self
+                        self.condition_dim = config.output_dim
+                    def eval(self):
+                        pass
+                    def to(self, device):
+                        return self
+                    def generate_claim(self, condition, seq_len):
+                        return torch.zeros(condition.size(0), seq_len, dtype=torch.long)
+                return Dummy()
+
+            with mock.patch.object(HierarchicalClaimsModel, 'load_from_checkpoint', side_effect=fake_load):
+                with mock.patch.object(torch.cuda, 'is_available', return_value=False):
+                    argv = ['generate_claims.py', path, '--num', '1']
+                    with mock.patch.object(sys, 'argv', argv):
+                        gen.main()
+            cfg = captured['config']
+            self.assertEqual(cfg.cpt_vocab_size, 5)
+            self.assertEqual(cfg.icd_vocab_size, 6)
+            self.assertEqual(cfg.ttnc_vocab_size, 3)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- patch `generate_claims.py` to recover vocab sizes from checkpoints
- add regression test covering CLI loading logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683cca9d226c832cb7898d61b19ab286