### PR TITLE
Add prediction CSV script

### DIFF
--- a/scripts/predict_to_csv.py
+++ b/scripts/predict_to_csv.py
@@ -1,0 +1,81 @@
+"""Generate claim predictions and compare with actuals, saving results to CSV."""
+import argparse
+import torch
+import pandas as pd
+from torch.utils.data import DataLoader
+
+from jepa_utils.config import Config
+from jepa_utils.data_prep import prepare_data
+from jepa_utils.prediction_utils import decode_predicted_codes
+from jepa_models.hierarchical_model import HierarchicalClaimsModel
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="Evaluate model and write predictions to CSV")
+    parser.add_argument("checkpoint", help="Path to trained checkpoint")
+    parser.add_argument("--output", default="predictions.csv", help="CSV file to write")
+    args = parser.parse_args(argv)
+
+    config = Config()
+    _, _, eval_dataset, _, config, dataset = prepare_data(config)
+
+    model = HierarchicalClaimsModel.load_from_checkpoint(args.checkpoint, config=config, strict=False)
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    model = model.to(device)
+    model.eval()
+
+    dataloader = DataLoader(eval_dataset, batch_size=128, collate_fn=dataset.collate_fn, shuffle=False)
+
+    results = []
+    with torch.no_grad():
+        for batch in dataloader:
+            cpt_tensor, icd_tensor, ttnc_tensor, target = batch
+            cpt_tensor = cpt_tensor.to(device)
+            icd_tensor = icd_tensor.to(device)
+            ttnc_tensor = ttnc_tensor.to(device)
+            target = target.to(device)
+
+            outputs = model(
+                cpt_tensor=cpt_tensor,
+                icd_tensor=icd_tensor,
+                ttnc_tensor=ttnc_tensor,
+                generation=True,
+                teacher_forcing=False,
+            )
+
+            predicted_cpt_codes = outputs["predicted_cpt_codes"]
+            predicted_icd_codes = outputs["predicted_icd_codes"]
+            predicted_ttnc_code = outputs["predicted_ttnc_code"]
+
+            decoded_cpt = decode_predicted_codes(predicted_cpt_codes, config.cpt_id_to_token)
+            decoded_icd = decode_predicted_codes(predicted_icd_codes, config.icd_id_to_token)
+
+            for i in range(cpt_tensor.size(0)):
+                predicted_cpt_list = decoded_cpt[i]
+                predicted_icd_list = decoded_icd[i]
+                actual_cpt_indices = cpt_tensor[i, -1, :].tolist()
+                actual_cpt = [config.cpt_id_to_token.get(idx, "<UNK>") for idx in actual_cpt_indices if idx != 0]
+                actual_icd_indices = icd_tensor[i, -1, :].tolist()
+                actual_icd = [config.icd_id_to_token.get(idx, "<UNK>") for idx in actual_icd_indices if idx != 0]
+                predicted_ttnc_idx = predicted_ttnc_code[i].item()
+                predicted_ttnc = config.ttnc_id_to_token.get(predicted_ttnc_idx, "<UNK>")
+                actual_ttnc_idx = ttnc_tensor[i, -1].item()
+                actual_ttnc = config.ttnc_id_to_token.get(actual_ttnc_idx, "<UNK>") if actual_ttnc_idx != 0 else ""
+
+                results.append(
+                    {
+                        "predicted_cpt": " ".join(predicted_cpt_list),
+                        "actual_cpt": " ".join(actual_cpt),
+                        "predicted_icd": " ".join(predicted_icd_list),
+                        "actual_icd": " ".join(actual_icd),
+                        "predicted_ttnc": predicted_ttnc,
+                        "actual_ttnc": actual_ttnc,
+                        "target": target[i].item(),
+                    }
+                )
+
+    pd.DataFrame(results).to_csv(args.output, index=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_predict_to_csv.py
+++ b/tests/test_predict_to_csv.py
@@ -1,0 +1,56 @@
+import sys
+import unittest
+from unittest import mock
+import torch
+from torch.utils.data import DataLoader, TensorDataset
+
+import scripts.predict_to_csv as predict
+from jepa_utils.config import Config
+
+
+class TestPredictToCSV(unittest.TestCase):
+    def test_main_writes_csv(self):
+        cfg = Config()
+        cfg.cpt_id_to_token = {0: '<PAD>', 1: 'cpt1'}
+        cfg.icd_id_to_token = {0: '<PAD>', 1: 'icd1'}
+        cfg.ttnc_id_to_token = {0: '<PAD>', 1: 'ttnc1'}
+        cfg.cpt_vocab_size = 2
+        cfg.icd_vocab_size = 2
+        cfg.ttnc_vocab_size = 2
+
+        cpt = torch.tensor([[[1, 0]]])
+        icd = torch.tensor([[[1, 0]]])
+        ttnc = torch.tensor([[1]])
+        target = torch.tensor([0.0])
+        dataset = TensorDataset(cpt, icd, ttnc, target)
+        dataset.collate_fn = lambda batch: tuple(torch.stack(items) for items in zip(*batch))
+        loader = DataLoader(dataset, batch_size=1)
+
+        def fake_prepare(config):
+            return dataset, loader, dataset, loader, cfg, dataset
+
+        class DummyModel:
+            def __init__(self):
+                self.config = cfg
+            def eval(self):
+                pass
+            def to(self, device):
+                return self
+            def __call__(self, cpt_tensor=None, icd_tensor=None, ttnc_tensor=None, generation=None, teacher_forcing=None):
+                return {
+                    'predicted_cpt_codes': cpt_tensor[:, -1],
+                    'predicted_icd_codes': icd_tensor[:, -1],
+                    'predicted_ttnc_code': ttnc_tensor[:, -1]
+                }
+
+        with mock.patch.object(predict, 'prepare_data', side_effect=fake_prepare):
+            with mock.patch.object(predict.HierarchicalClaimsModel, 'load_from_checkpoint', return_value=DummyModel()):
+                with mock.patch('pandas.DataFrame.to_csv') as mock_csv:
+                    argv = ['predict_to_csv.py', 'model.ckpt']
+                    with mock.patch.object(sys, 'argv', argv):
+                        predict.main()
+                    mock_csv.assert_called_once()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a `predict_to_csv.py` helper to export predicted vs actual codes
- unit test for the new CLI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683da94ec48c832cbb2a50afd59e8e6e