### PR TITLE
Implement diffusion training improvements

### DIFF
--- a/diffusion_models/claim_d3pm.py
+++ b/diffusion_models/claim_d3pm.py
@@ -20,7 +20,11 @@ class ClaimD3PM(pl.LightningModule):
         # the probability of replacing a token with uniform noise at each time
         # step. Using a 1-D tensor drastically reduces memory usage compared to
         # the previous pre-computed transition tensor of shape ``(T, V, V)``.
-        self.alphas = nn.Parameter(torch.linspace(0.001, 0.25, self.num_timesteps))
+        # Cosine noise schedule starting at ~0.05 and rising to ~0.25
+        t = torch.arange(self.num_timesteps, dtype=torch.float32)
+        self.alphas = nn.Parameter(
+            0.25 - 0.20 * torch.cos(0.5 * torch.pi * t / (self.num_timesteps - 1))
+        )
 
         self.token_embed = nn.Embedding(vocab_size, config.embedding_dim)
         self.time_embed = nn.Embedding(self.num_timesteps, config.embedding_dim)
@@ -34,6 +38,8 @@ class ClaimD3PM(pl.LightningModule):
         self.denoiser = nn.TransformerEncoder(encoder_layer, num_layers=4)
         self.film_fc = nn.Linear(condition_dim, config.embedding_dim * 2)
         self.output_proj = nn.Linear(config.embedding_dim, vocab_size)
+        # Learnable default condition used during diffusion pretrain
+        self.default_condition = nn.Parameter(torch.zeros(condition_dim))
         self.lr = getattr(config, "lr", 1e-3)
 
     def load_state_dict(self, state_dict, strict=True):
@@ -64,12 +70,18 @@ class ClaimD3PM(pl.LightningModule):
     def p_losses(self, x0, t, condition):
         x_t = self.q_sample(x0, t)
         logits = self.denoise(x_t, t, condition)
-        loss = F.cross_entropy(logits.view(-1, self.vocab_size), x0.view(-1))
+        loss = F.cross_entropy(
+            logits.view(-1, self.vocab_size),
+            x0.view(-1),
+            ignore_index=0,
+        )
         return loss
 
     def forward(self, tokens, condition=None):
         b = tokens.size(0)
         t = torch.randint(0, self.num_timesteps, (b,), device=tokens.device)
+        if condition is None:
+            condition = self.default_condition.expand(b, -1)
         loss = self.p_losses(tokens, t, condition)
         return loss
 
@@ -97,6 +109,7 @@ class ClaimD3PM(pl.LightningModule):
         tokens = torch.cat([cpt_tokens, icd_tokens, ttnc_tokens.unsqueeze(1)], dim=1)
         loss = self.forward(tokens)
         self.log("loss", loss, on_step=True, on_epoch=True, prog_bar=True)
-        # Explicitly log diffusion cross-entropy for monitoring
+        # Explicitly log diffusion cross-entropy and perplexity for monitoring
         self.log("diffusion_ce", loss, on_step=True, on_epoch=True, prog_bar=True)
+        self.log("diff_ppl", torch.exp(loss), on_step=True, on_epoch=True, prog_bar=True)
         return loss

--- a/jepa_models/hierarchical_model.py
+++ b/jepa_models/hierarchical_model.py
@@ -328,7 +328,7 @@ class HierarchicalClaimsModel(pl.LightningModule):
             'task': nn.Parameter(torch.zeros(1)),
             'token_pred': nn.Parameter(torch.zeros(1)),
             'sae': nn.Parameter(torch.zeros(1)),
-            'diffusion': nn.Parameter(torch.zeros(1)),
+            'diffusion': nn.Parameter(torch.tensor(3.0)),
         })
 
         if self.use_predictor_head:
@@ -1203,10 +1203,19 @@ class HierarchicalClaimsModel(pl.LightningModule):
         if self.use_predictor_head:
             collect_params(self.non_linear_predictor, generator_params)
 
+        diffusion_params = []
+        if self.use_diffusion and hasattr(self, "diffusion_model"):
+            collect_params(self.diffusion_model, diffusion_params)
+
         optimizer_gen = torch.optim.AdamW(
             [
                 {'params': adapter_params, 'lr': self.adapter_lr, 'weight_decay': 1e-4},
                 {'params': generator_params, 'lr': self.generator_lr, 'weight_decay': 1e-4},
+                {
+                    'params': diffusion_params,
+                    'lr': self.generator_lr * 10,
+                    'weight_decay': 1e-4,
+                },
             ]
         )
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -4,3 +4,4 @@ from . import test_data_loader
 from . import test_diffusion_integration
 from . import test_phase_cli
 from . import test_diffusion_condition
+from . import test_diffusion_training

--- a/tests/test_diffusion_training.py
+++ b/tests/test_diffusion_training.py
@@ -1,0 +1,42 @@
+import unittest
+import torch
+from torch.utils.data import DataLoader, Dataset
+from jepa_utils.config import Config
+from models.diffusion import ClaimD3PM
+
+class ConstantDataset(Dataset):
+    def __init__(self, num_samples, seq_len, token=1):
+        self.data = torch.full((num_samples, seq_len), token, dtype=torch.long)
+    def __len__(self):
+        return len(self.data)
+    def __getitem__(self, idx):
+        return self.data[idx]
+
+class TestDiffusionTraining(unittest.TestCase):
+    def test_single_epoch_reduces_ce(self):
+        cfg = Config()
+        cfg.cpt_vocab_size = 3
+        cfg.icd_vocab_size = 3
+        cfg.ttnc_vocab_size = 2
+        cfg.embedding_dim = 4
+        cfg.diffusion_steps = 5
+        vocab_size = cfg.cpt_vocab_size + cfg.icd_vocab_size + cfg.ttnc_vocab_size + 3
+        dataset = ConstantDataset(20, 6)
+        loader = DataLoader(dataset, batch_size=4)
+        model = ClaimD3PM(cfg, vocab_size, condition_dim=cfg.embedding_dim)
+        optimizer = torch.optim.Adam(model.parameters(), lr=0.1)
+        model.train()
+        for tokens in loader:
+            optimizer.zero_grad()
+            loss = model(tokens)
+            loss.backward()
+            optimizer.step()
+        # Evaluate cross-entropy after one epoch
+        model.eval()
+        with torch.no_grad():
+            losses = [model(batch) for batch in loader]
+        avg_loss = torch.stack(losses).mean()
+        self.assertLess(avg_loss.item(), 2.0)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- enhance `ClaimD3PM` with cosine noise schedule
- mask PAD tokens and always pass dummy condition
- log diffusion perplexity
- set diffusion logvar init to 3 and give diffusion params a separate LR group
- add unit test verifying CE reduction after one epoch

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683dce4392f8832c8bf0a08870d16b24