### PR TITLE
Implement variable-length claims and duplicate suppression

### DIFF
--- a/data/vocab.py
+++ b/data/vocab.py
@@ -30,7 +30,10 @@ def create_vocab(df, min_freq=5):
 
     cpt_vocab = build_vocab(cpt_counter, reserved_tokens=['<PAD>', '<UNK>'], min_freq=min_freq)
     icd_vocab = build_vocab(icd_counter, reserved_tokens=['<PAD>', '<UNK>'], min_freq=min_freq)
-    ttnc_vocab = build_vocab(ttnc_counter, reserved_tokens=['<PAD>', '<UNK>'], min_freq=min_freq)
+    # Time-to-next-claim tokens do not use an ``<UNK>`` entry. Any gap not
+    # present in the vocabulary will be clamped to the nearest valid bin during
+    # preprocessing, so the reserved tokens only include ``<PAD>``.
+    ttnc_vocab = build_vocab(ttnc_counter, reserved_tokens=['<PAD>'], min_freq=min_freq)
 
     # Reverse mapping for unified vocabulary (if needed)
     unified_vocab_reverse = {idx: token for token, idx in {**cpt_vocab, **icd_vocab, **ttnc_vocab}.items()}

--- a/diffusion_models/claim_d3pm.py
+++ b/diffusion_models/claim_d3pm.py
@@ -36,6 +36,14 @@ class ClaimD3PM(pl.LightningModule):
             batch_first=True,
         )
         self.denoiser = nn.TransformerEncoder(encoder_layer, num_layers=4)
+        # Causal inter-slot attention layer used to suppress duplicates
+        self.slot_attn = nn.TransformerEncoderLayer(
+            d_model=config.embedding_dim,
+            nhead=4,
+            dim_feedforward=config.embedding_dim * 4,
+            dropout=0.0,
+            batch_first=True,
+        )
         self.film_fc = nn.Linear(condition_dim, config.embedding_dim * 2)
         self.output_proj = nn.Linear(config.embedding_dim, vocab_size)
         # Learnable default condition used during diffusion pretrain
@@ -65,6 +73,10 @@ class ClaimD3PM(pl.LightningModule):
             gamma, beta = self.film_fc(condition).chunk(2, dim=-1)
             emb = emb * (1 + gamma.unsqueeze(1)) + beta.unsqueeze(1)
         h = self.denoiser(emb)
+        # Causal mask so slot j attends only to slots < j
+        seq_len = h.size(1)
+        mask = torch.triu(torch.ones(seq_len, seq_len, device=h.device), diagonal=1).bool()
+        h = self.slot_attn(h, mask)
         return self.output_proj(h)
 
     def p_losses(self, x0, t, condition):
@@ -95,6 +107,19 @@ class ClaimD3PM(pl.LightningModule):
             cond = self.denoise(x, t, condition)
             logits = uncond + self.guidance_scale * (cond - uncond)
             x = Categorical(logits=logits).sample()
+
+        dup_rates = []
+        for i in range(x.size(0)):
+            tokens = x[i].tolist()
+            if 0 in tokens:
+                tokens = tokens[: tokens.index(0)]
+            dup_count = len(tokens) - len(set(tokens))
+            dup_rates.append(dup_count / max(len(tokens), 1))
+            tokens = list(dict.fromkeys(tokens))
+            padded = tokens + [0] * (seq_len - len(tokens))
+            x[i] = torch.tensor(padded, device=x.device)
+
+        self.last_dup_rate = float(sum(dup_rates) / len(dup_rates)) if dup_rates else 0.0
         return x
 
     def configure_optimizers(self):
@@ -112,4 +137,7 @@ class ClaimD3PM(pl.LightningModule):
         # Explicitly log diffusion cross-entropy and perplexity for monitoring
         self.log("diffusion_ce", loss, on_step=True, on_epoch=True, prog_bar=True)
         self.log("diff_ppl", torch.exp(loss), on_step=True, on_epoch=True, prog_bar=True)
+        with torch.no_grad():
+            _ = self.generate_claim(self.default_condition.expand(tokens.size(0), -1), seq_len=tokens.size(1))
+            self.log("dup_rate", getattr(self, "last_dup_rate", 0.0), on_step=True, on_epoch=True, prog_bar=True)
         return loss

--- a/jepa_utils/dataset.py
+++ b/jepa_utils/dataset.py
@@ -10,6 +10,9 @@ class ClaimsDataset(Dataset):
         self.cpt_vocab = cpt_vocab
         self.icd_vocab = icd_vocab
         self.ttnc_vocab = ttnc_vocab
+        self.ttnc_bins = sorted(
+            int(tok.split('_')[1]) for tok in ttnc_vocab if tok.startswith('ttnc_')
+        )
 
         # Store config parameters
         self.max_claims_len = config.max_claims_len
@@ -118,8 +121,16 @@ class ClaimsDataset(Dataset):
                     icd_claim = random.sample(icd_claim, max_icd_tokens)
                 icd_tokens.append([self.icd_vocab.get(token, self.icd_vocab.get('<UNK>', 0)) for token in icd_claim] + [self.icd_vocab.get('<PAD>', 0)] * (max_icd_tokens - len(icd_claim)))
 
-                # Handle TTNC tokens
-                ttnc_tokens.append(self.ttnc_vocab.get(claim['ttnc'], self.ttnc_vocab.get('<PAD>', 0)))
+                # Handle TTNC tokens with clamping of out-of-range gaps
+                ttoken = self.ttnc_vocab.get(claim['ttnc'])
+                if ttoken is None:
+                    try:
+                        gap = int(claim['ttnc'].split('_')[1])
+                        nearest = min(self.ttnc_bins, key=lambda x: abs(x - gap))
+                        ttoken = self.ttnc_vocab.get(f'ttnc_{nearest}', self.ttnc_vocab.get('<PAD>', 0))
+                    except Exception:
+                        ttoken = self.ttnc_vocab.get('<PAD>', 0)
+                ttnc_tokens.append(ttoken)
 
             # Pad claims to max_claims_len if they are shorter
             num_padding = max_claims_len - len(cpt_tokens)

--- a/tests/test_pad_to_eos.py
+++ b/tests/test_pad_to_eos.py
@@ -1,0 +1,48 @@
+import unittest
+import torch
+from jepa_utils.config import Config
+from diffusion_models.claim_d3pm import ClaimD3PM
+
+class TestPadToEos(unittest.TestCase):
+    def test_generated_length_histogram(self):
+        cfg = Config()
+        cfg.cpt_vocab_size = 2
+        cfg.icd_vocab_size = 1
+        cfg.ttnc_vocab_size = 1
+        cfg.embedding_dim = 8
+        cfg.diffusion_steps = 2
+        vocab_size = cfg.cpt_vocab_size + cfg.icd_vocab_size + cfg.ttnc_vocab_size + 3
+        model = ClaimD3PM(cfg, vocab_size, cfg.embedding_dim)
+
+        real_lengths = torch.tensor([2,3,4,3,2])
+        seq_len = 5
+        tokens = torch.zeros(len(real_lengths), seq_len, dtype=torch.long)
+        for i,l in enumerate(real_lengths):
+            tokens[i,:l] = torch.randint(1, vocab_size, (l,))
+
+        optim = torch.optim.Adam(model.parameters(), lr=0.01)
+        for _ in range(5):
+            optim.zero_grad()
+            t = torch.randint(0, cfg.diffusion_steps, (tokens.size(0),))
+            loss = model.p_losses(tokens, t, model.default_condition.expand(tokens.size(0), -1))
+            loss.backward()
+            optim.step()
+
+        model.eval()
+        with torch.no_grad():
+            samples = model.generate_claim(model.default_condition.expand(100, -1), seq_len)
+        lengths = []
+        for row in samples:
+            row = row.tolist()
+            length = row.index(0) if 0 in row else len(row)
+            lengths.append(length)
+        lengths = torch.tensor(lengths)
+        hist_real = torch.bincount(real_lengths, minlength=seq_len+1).float()
+        hist_real /= hist_real.sum()
+        hist_gen = torch.bincount(lengths, minlength=seq_len+1).float()
+        hist_gen /= hist_gen.sum()
+        diff = torch.abs(hist_real - hist_gen)
+        self.assertTrue(torch.all(diff <= 0.3))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- handle TTNC tokens without `<UNK>` and clamp unknown gaps
- add inter-slot causal attention layer and duplicate cleanup logic
- compute duplicate rate metric during diffusion pretraining
- truncate generated sequences at first `<PAD>` token
- add unit test for PAD→EOS behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683dfbd62f08832cad182f2812de5bdf