### PR TITLE
Add logvar warmup scheduling

### DIFF
--- a/jepa_models/hierarchical_model.py
+++ b/jepa_models/hierarchical_model.py
@@ -197,6 +197,7 @@ class HierarchicalClaimsModel(pl.LightningModule):
         self.use_diffusion = getattr(config, 'use_diffusion', False)
         self.diffusion_type = getattr(config, 'diffusion_type', 'continuous')
         self.diffusion_weight = getattr(config, 'diffusion_weight', 1.0)
+        self.warmup_logvar_epochs = getattr(config, 'warmup_logvar_epochs', 3)
         self.debug_generation = getattr(config, 'debug_generation', False)
         self.cpt_vocab_size = config.cpt_vocab_size
         self.icd_vocab_size = config.icd_vocab_size
@@ -1111,6 +1112,13 @@ class HierarchicalClaimsModel(pl.LightningModule):
                     _ = param.grad
             self._grad_check_done = True
 
+    def on_train_epoch_start(self):
+        """Freeze or unfreeze log-variance parameters based on epoch."""
+        freeze = self.current_epoch < self.warmup_logvar_epochs
+        for p in self.log_vars.parameters():
+            p.requires_grad = not freeze
+        self.log("logvar_frozen", float(freeze), prog_bar=True, logger=True)
+
 
     def train_linear_regression(self, X_sample, y_sample):
         """Train the linear model using sampled representations"""
@@ -1236,11 +1244,16 @@ class HierarchicalClaimsModel(pl.LightningModule):
         collect_params(self.log_vars, generator_params)
         if self.use_token_prediction_head:
             collect_params(self.logits_generator, generator_params)
-            generator_params.append(self.threshold)
-            generator_params.append(self.lambda_entropy)
+            if self.threshold.requires_grad:
+                generator_params.append(self.threshold)
+            if self.lambda_entropy.requires_grad:
+                generator_params.append(self.lambda_entropy)
 
         if self.use_predictor_head:
             collect_params(self.non_linear_predictor, generator_params)
+
+        adapter_params = [p for p in adapter_params if p.requires_grad]
+        generator_params = [p for p in generator_params if p.requires_grad]
 
         optimizer_gen = torch.optim.AdamW(
             [

--- a/jepa_utils/config.py
+++ b/jepa_utils/config.py
@@ -61,6 +61,7 @@ class Config:
     diffusion_weight: float = 1.0  # Weight for diffusion loss when joint training
     diffusion_type: str = "discrete"  # continuous | discrete
     diffusion_steps: int = 100
+    warmup_logvar_epochs: int = 3
     cpt_prob_agg: str = "max"  # max | mean | sum
     ttnc_temperature: float = 1.0
     base_cpt_threshold: float = 0.5

--- a/tests/test_logvar_warmup.py
+++ b/tests/test_logvar_warmup.py
@@ -1,0 +1,58 @@
+import unittest
+import torch
+from jepa_utils.config import Config
+from jepa_models.hierarchical_model import HierarchicalClaimsModel
+
+class TestLogvarWarmup(unittest.TestCase):
+    def setUp(self):
+        cfg = Config()
+        cfg.use_diffusion = False
+        cfg.use_sparse_autoencoder = False
+        cfg.use_token_prediction_head = False
+        cfg.use_predictor_head = False
+        cfg.use_level1 = False
+        cfg.cpt_rarity_scores = None
+        cfg.icd_rarity_scores = None
+        cfg.ttnc_rarity_scores = None
+        cfg.cpt_vocab_size = 5
+        cfg.icd_vocab_size = 5
+        cfg.ttnc_vocab_size = 3
+        cfg.max_cpt_tokens = 2
+        cfg.max_icd_tokens = 2
+        cfg.max_claims_len = 2
+        cfg.warmup_logvar_epochs = 3
+        self.model = HierarchicalClaimsModel(cfg)
+        batch_size = 2
+        self.batch = (
+            torch.randint(1, cfg.cpt_vocab_size, (batch_size, cfg.max_claims_len, cfg.max_cpt_tokens)),
+            torch.randint(1, cfg.icd_vocab_size, (batch_size, cfg.max_claims_len, cfg.max_icd_tokens)),
+            torch.randint(1, cfg.ttnc_vocab_size, (batch_size, cfg.max_claims_len)),
+            torch.randn(batch_size)
+        )
+
+    def test_warmup(self):
+        optim, _ = self.model.configure_optimizers()
+        optim = optim[0]
+        grad_epoch0 = []
+        grad_epoch4 = []
+        from types import SimpleNamespace
+        self.model.log = lambda *a, **k: None
+        for epoch in range(5):
+            self.model.trainer = SimpleNamespace(current_epoch=epoch, global_step=0)
+            self.model.on_train_epoch_start()
+            optim.zero_grad()
+            loss = self.model.training_step(self.batch, 0)
+            loss.backward()
+            if epoch == 0:
+                for p in self.model.log_vars.parameters():
+                    grad_epoch0.append(p.grad)
+            if epoch == 4:
+                for p in self.model.log_vars.parameters():
+                    grad_epoch4.append(p.grad)
+            optim.step()
+        for g in grad_epoch0:
+            self.assertIsNone(g)
+        self.assertTrue(any(g is not None and g.abs().sum() > 0 for g in grad_epoch4))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- allow configuring `warmup_logvar_epochs` in `Config`
- enable freezing/unfreezing of loss log‐variances with epoch warm‑up
- ignore frozen parameters when building optimizer groups
- track if logvars are frozen each epoch
- test warm-up behavior for logvars

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683e143b3b4c832c9d659795757557a9