### PR TITLE
Implement logvar warmup training freeze

### DIFF
--- a/jepa_models/hierarchical_model.py
+++ b/jepa_models/hierarchical_model.py
@@ -197,6 +197,7 @@ class HierarchicalClaimsModel(pl.LightningModule):
         self.use_gated_fusion = config.use_gated_fusion
         self.use_diffusion = getattr(config, 'use_diffusion', False)
         self.diffusion_weight = getattr(config, 'diffusion_weight', 1.0)
+        self.warmup_logvar_epochs = getattr(config, 'warmup_logvar_epochs', 3)
         self.debug_generation = getattr(config, 'debug_generation', False)
         self.cpt_vocab_size = config.cpt_vocab_size
         self.icd_vocab_size = config.icd_vocab_size
@@ -1069,6 +1070,13 @@ class HierarchicalClaimsModel(pl.LightningModule):
 
             self.prediction_block_lvl2.on_epoch_end()
 
+    def on_train_epoch_start(self):
+        """Freeze or unfreeze log variance parameters based on epoch."""
+        frozen = self.current_epoch < self.warmup_logvar_epochs
+        for p in self.log_vars.parameters():
+            p.requires_grad = not frozen
+        self.log("logvar_frozen", float(frozen), prog_bar=True, logger=True)
+
     def on_after_backward(self):
         if not self._grad_check_done:
             for name, param in self.named_parameters():
@@ -1224,30 +1232,33 @@ class HierarchicalClaimsModel(pl.LightningModule):
         if self.use_diffusion and hasattr(self, "diffusion_model"):
             collect_params(self.diffusion_model, diffusion_params)
 
-        optimizer_gen = torch.optim.AdamW(
-            [
-                {
-                    'params': adapter_params,
-                    'lr': self.adapter_lr,
-                    'weight_decay': 1e-4,
-                },
-                {
-                    'params': generator_params,
-                    'lr': self.generator_lr,
-                    'weight_decay': 1e-4,
-                },
-                {
-                    'params': logvar_params,
-                    'lr': self.generator_lr,
-                    'weight_decay': 1e-3,
-                },
-                {
-                    'params': diffusion_params,
-                    'lr': self.generator_lr * 10,
-                    'weight_decay': 1e-4,
-                },
-            ]
-        )
+        param_groups = []
+        if adapter_params:
+            param_groups.append({
+                'params': adapter_params,
+                'lr': self.adapter_lr,
+                'weight_decay': 1e-4,
+            })
+        if generator_params:
+            param_groups.append({
+                'params': generator_params,
+                'lr': self.generator_lr,
+                'weight_decay': 1e-4,
+            })
+        if logvar_params:
+            param_groups.append({
+                'params': logvar_params,
+                'lr': self.generator_lr,
+                'weight_decay': 1e-3,
+            })
+        if diffusion_params:
+            param_groups.append({
+                'params': diffusion_params,
+                'lr': self.generator_lr * 10,
+                'weight_decay': 1e-4,
+            })
+
+        optimizer_gen = torch.optim.AdamW(param_groups)
 
         scheduler = torch.optim.lr_scheduler.StepLR(
             optimizer_gen, step_size=2, gamma=0.5

--- a/jepa_utils/config.py
+++ b/jepa_utils/config.py
@@ -64,6 +64,7 @@ class Config:
     diffusion_steps: int = 100
     guidance_scale: float = 4.0
     freeze_denoiser_core: bool = False
+    warmup_logvar_epochs: int = 3
     cpt_prob_agg: str = "max"  # max | mean | sum
     ttnc_temperature: float = 1.0
     base_cpt_threshold: float = 0.5

--- a/tests/test_logvar_warmup.py
+++ b/tests/test_logvar_warmup.py
@@ -1,0 +1,48 @@
+import unittest
+import torch
+from jepa_utils.config import Config
+from jepa_models.hierarchical_model import HierarchicalClaimsModel
+
+class TestLogVarWarmup(unittest.TestCase):
+    def test_logvar_freeze_warmup(self):
+        cfg = Config()
+        cfg.cpt_vocab_size = 3
+        cfg.icd_vocab_size = 3
+        cfg.ttnc_vocab_size = 2
+        cfg.cpt_rarity_scores = None
+        cfg.icd_rarity_scores = None
+        cfg.ttnc_rarity_scores = None
+        cfg.use_diffusion = False
+        cfg.use_sparse_autoencoder = False
+        cfg.use_token_prediction_head = False
+        cfg.use_predictor_head = False
+        cfg.use_level1 = False
+        cfg.warmup_logvar_epochs = 3
+
+        model = HierarchicalClaimsModel(cfg)
+        optimizer = torch.optim.AdamW(model.parameters(), lr=1e-3)
+
+        batch_size = 2
+        cpt = torch.randint(1, cfg.cpt_vocab_size, (batch_size, cfg.max_claims_len, cfg.max_cpt_tokens))
+        icd = torch.randint(1, cfg.icd_vocab_size, (batch_size, cfg.max_claims_len, cfg.max_icd_tokens))
+        ttnc = torch.randint(1, cfg.ttnc_vocab_size, (batch_size, cfg.max_claims_len))
+        target = torch.randn(batch_size)
+        batch = (cpt, icd, ttnc, target)
+
+        import types
+        for epoch in range(5):
+            model._trainer = types.SimpleNamespace(current_epoch=epoch, global_step=0)
+            model.log = lambda *a, **k: None
+            model.on_train_epoch_start()
+            optimizer.zero_grad()
+            loss = model.training_step(batch, 0)
+            loss.backward()
+            optimizer.step()
+            grads = [p.grad for p in model.log_vars.values()]
+            if epoch == 0:
+                self.assertTrue(all(g is None or torch.all(g == 0) for g in grads))
+            if epoch == 4:
+                self.assertTrue(any(g is not None and torch.any(g != 0) for g in grads))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `warmup_logvar_epochs` to `Config`
- freeze/unfreeze log variance parameters at `on_train_epoch_start`
- exclude empty parameter groups from optimizer
- test gradient behaviour during logvar warmup

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683e167749b4832cbedd8f39765ff5b7