### PR TITLE
Add denoiser kickstart implementation

### DIFF
--- a/diffusion_models/claim_d3pm.py
+++ b/diffusion_models/claim_d3pm.py
@@ -15,6 +15,9 @@ class ClaimD3PM(pl.LightningModule):
         self.condition_dim = condition_dim
         self.num_timesteps = getattr(config, "diffusion_steps", 100)
         self.guidance_scale = getattr(config, "guidance_scale", 4.0)
+        self.teacher_forcing_epochs = getattr(config, "teacher_forcing_epochs", 0)
+        self.label_smoothing = getattr(config, "diffusion_label_smoothing", 0.0)
+        self.kickstart_lr_scale = getattr(config, "kickstart_lr_scale", 1.0)
 
         # Transition noise schedule (flatten-to-uniform). ``alphas`` controls
         # the probability of replacing a token with uniform noise at each time
@@ -22,9 +25,11 @@ class ClaimD3PM(pl.LightningModule):
         # the previous pre-computed transition tensor of shape ``(T, V, V)``.
         # Cosine noise schedule starting at ~0.05 and rising to ~0.25
         t = torch.arange(self.num_timesteps, dtype=torch.float32)
-        self.alphas = nn.Parameter(
-            0.25 - 0.20 * torch.cos(0.5 * torch.pi * t / (self.num_timesteps - 1))
-        )
+        base_schedule = 0.25 - 0.20 * torch.cos(0.5 * torch.pi * t / (self.num_timesteps - 1))
+        self.register_buffer("base_alphas", base_schedule)
+        reset_schedule = torch.linspace(0.02, 0.25, self.num_timesteps)
+        self.register_buffer("reset_alphas", reset_schedule)
+        self.alphas = nn.Parameter(self.base_alphas.clone())
 
         self.token_embed = nn.Embedding(vocab_size, config.embedding_dim)
         self.time_embed = nn.Embedding(self.num_timesteps, config.embedding_dim)
@@ -44,7 +49,7 @@ class ClaimD3PM(pl.LightningModule):
             dropout=0.0,
             batch_first=True,
         )
-        self.film_fc = nn.Linear(condition_dim, config.embedding_dim * 2)
+        self.film_fc = nn.Linear(condition_dim + config.embedding_dim, config.embedding_dim * 2)
         self.output_proj = nn.Linear(config.embedding_dim, vocab_size)
         # Learnable default condition used during diffusion pretrain
         self.default_condition = nn.Parameter(torch.zeros(condition_dim))
@@ -64,13 +69,16 @@ class ClaimD3PM(pl.LightningModule):
         noise = torch.randint_like(x0, low=0, high=self.vocab_size)
         return torch.where(keep_mask, x0, noise)
 
-    def denoise(self, x_t, t, condition=None):
+    def denoise(self, x_t, t, condition=None, teacher_embed=None):
         token_emb = self.token_embed(x_t)
         time_emb = self.time_embed(t).unsqueeze(1)
         time_emb = time_emb.expand(-1, x_t.size(1), -1)
         emb = token_emb + time_emb
         if condition is not None:
-            gamma, beta = self.film_fc(condition).chunk(2, dim=-1)
+            if teacher_embed is None:
+                teacher_embed = torch.zeros(condition.size(0), self.token_embed.embedding_dim, device=condition.device)
+            film_input = torch.cat([condition, teacher_embed], dim=-1)
+            gamma, beta = self.film_fc(film_input).chunk(2, dim=-1)
             emb = emb * (1 + gamma.unsqueeze(1)) + beta.unsqueeze(1)
         h = self.denoiser(emb)
         # Causal mask so slot j attends only to slots < j
@@ -81,11 +89,15 @@ class ClaimD3PM(pl.LightningModule):
 
     def p_losses(self, x0, t, condition):
         x_t = self.q_sample(x0, t)
-        logits = self.denoise(x_t, t, condition)
+        teacher_embed = None
+        if self.current_epoch < self.teacher_forcing_epochs:
+            teacher_embed = self.token_embed(x0).mean(dim=1)
+        logits = self.denoise(x_t, t, condition, teacher_embed)
         loss = F.cross_entropy(
             logits.view(-1, self.vocab_size),
             x0.view(-1),
             ignore_index=0,
+            label_smoothing=self.label_smoothing,
         )
         return loss
 
@@ -123,7 +135,22 @@ class ClaimD3PM(pl.LightningModule):
         return x
 
     def configure_optimizers(self):
-        return torch.optim.Adam(self.parameters(), lr=self.lr)
+        high_lr_params = []
+        if hasattr(self.denoiser, "layers") and len(self.denoiser.layers) >= 2:
+            high_lr_params += list(self.denoiser.layers[0].parameters())
+            high_lr_params += list(self.denoiser.layers[1].parameters())
+        high_lr_params += list(self.token_embed.parameters())
+        high_lr_params += list(self.time_embed.parameters())
+
+        high_lr_set = set(high_lr_params)
+        base_params = [p for p in self.parameters() if p not in high_lr_set]
+
+        return torch.optim.Adam(
+            [
+                {"params": base_params, "lr": self.lr},
+                {"params": high_lr_params, "lr": self.lr * self.kickstart_lr_scale},
+            ]
+        )
 
     def training_step(self, batch, batch_idx):
         """Standard Lightning training step for diffusion pretraining."""
@@ -140,4 +167,31 @@ class ClaimD3PM(pl.LightningModule):
         with torch.no_grad():
             _ = self.generate_claim(self.default_condition.expand(tokens.size(0), -1), seq_len=tokens.size(1))
             self.log("dup_rate", getattr(self, "last_dup_rate", 0.0), on_step=True, on_epoch=True, prog_bar=True)
+        if not hasattr(self, "epoch_losses"):
+            self.epoch_losses = []
+        self.epoch_losses.append(loss.detach())
         return loss
+
+    def on_train_epoch_start(self):
+        if 100 <= self.current_epoch < 110:
+            self.alphas.data.copy_(self.reset_alphas)
+        elif self.current_epoch >= 110:
+            self.alphas.data.copy_(self.base_alphas)
+
+    def on_train_epoch_end(self):
+        if hasattr(self, "epoch_losses") and self.epoch_losses:
+            avg_loss = torch.stack(self.epoch_losses).mean()
+            current_ppl = float(torch.exp(avg_loss))
+            if not hasattr(self, "last_ppl"):
+                self.last_ppl = current_ppl
+                self.no_improve_epochs = 0
+            else:
+                improve = self.last_ppl / current_ppl
+                if improve < 1.05:
+                    self.no_improve_epochs += 1
+                else:
+                    self.no_improve_epochs = 0
+                self.last_ppl = current_ppl
+            if getattr(self, "no_improve_epochs", 0) >= 20 and self.trainer is not None:
+                self.trainer.should_stop = True
+        self.epoch_losses = []

--- a/implementation_plans/diffusion_implementation.py
+++ b/implementation_plans/diffusion_implementation.py
@@ -78,4 +78,11 @@ for implementing, refactoring, and unifying discrete‑diffusion with JEPA.
     G. Version bump
        • Update `__version__` to `0.4.0` (minor feature + cleanup).
 
+10.  **Denoiser Kickstart Plan**
+    • Backbone LR ×20 param‑group for layers 0‑1 and token/time embeddings.
+    • 5‑epoch teacher‑forcing window — concat code‑embedding oracle into FiLM.
+    • Temporary noise‑schedule reset: α₁ = 0.02 for epochs 100‑110, then linear ramp.
+    • Cross‑entropy label‑smoothing 0.1.
+    • Monitor `diff_ppl_improve`; if < 1.05 over 20 epochs → early‑exit.
+
 """

--- a/jepa_utils/config.py
+++ b/jepa_utils/config.py
@@ -64,6 +64,10 @@ class Config:
     diffusion_steps: int = 100
     guidance_scale: float = 4.0
     freeze_denoiser_core: bool = False
+    # Kickstart plan hyperparameters
+    teacher_forcing_epochs: int = 0
+    diffusion_label_smoothing: float = 0.0
+    kickstart_lr_scale: float = 1.0
     warmup_logvar_epochs: int = 3
     cpt_prob_agg: str = "max"  # max | mean | sum
     ttnc_temperature: float = 1.0


### PR DESCRIPTION
## Summary
- support teacher forcing, label smoothing and LR boosts in ClaimD3PM
- reset noise schedule during epochs 100-110 and early stop if perplexity plateaus
- expose kickstart hyperparameters in Config

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683e3535a7fc832c8bc7f5538d98e8e6