### PR TITLE
Enable diffusion-only finetune from joint checkpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,9 @@ Once training completes you can sample synthetic claims with:
 ```bash
 python scripts/generate_claims.py joint.ckpt --num 10
 ```
+During `--phase diffusion_only_finetune`, if the `--resume` checkpoint is a joint
+file the loader automatically freezes JEPA parameters and fine-tunes the
+diffusion module in place.
 ## Multi-Stage Training
 
 ### Stage 1 – Self-Supervised Representation Pre-Train

--- a/jepa_utils/__init__.py
+++ b/jepa_utils/__init__.py
@@ -1,0 +1,4 @@
+from .checkpoint_utils import checkpoint_has_prefixed_keys, freeze_non_diffusion
+
+from .checkpoint_utils import freeze_jepa
+

--- a/jepa_utils/checkpoint_utils.py
+++ b/jepa_utils/checkpoint_utils.py
@@ -1,0 +1,22 @@
+import torch
+
+
+def checkpoint_has_prefixed_keys(path: str) -> bool:
+    """Return True if the checkpoint contains keys starting with 'diffusion_model.'."""
+    ckpt = torch.load(path, map_location="cpu", weights_only=True)
+    state_dict = ckpt.get("state_dict", ckpt)
+    return any(k.startswith("diffusion_model.") for k in state_dict.keys())
+
+
+def freeze_non_diffusion(model):
+    """Freeze all parameters except those belonging to the diffusion model."""
+    for name, param in model.named_parameters():
+        if not name.startswith("diffusion_model"):
+            param.requires_grad = False
+
+def freeze_jepa(model):
+    """Freeze JEPA parameters (everything except diffusion)."""
+    for name, param in model.named_parameters():
+        if name.startswith("diffusion_model"):
+            continue
+        param.requires_grad = False

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -18,6 +18,7 @@ from jepa_utils.tensor_utils import calculate_entropy, adaptive_sampling
 from jepa_utils.metrics import calculate_rmse
 from jepa_utils.config import Config
 from jepa_utils.prediction_utils import decode_predicted_codes
+from jepa_utils import checkpoint_has_prefixed_keys, freeze_non_diffusion, freeze_jepa
 import copy
 
 
@@ -66,18 +67,42 @@ def main(argv=None):
         return
 
     if args.phase == "diffusion_only_finetune":
-        config.freeze_jepa = True
-        vocab_size = (
-            config.cpt_vocab_size + config.icd_vocab_size + config.ttnc_vocab_size + 3
-        )
         ckpt = args.resume or "diffusion_only.ckpt"
         if not os.path.exists(ckpt):
             raise FileNotFoundError(f"Checkpoint {ckpt} not found")
-        diffusion_model = ClaimD3PM.load_from_checkpoint(
-            ckpt,
-            config=config,
-            vocab_size=vocab_size,
-            condition_dim=config.output_dim,
+
+        if checkpoint_has_prefixed_keys(ckpt):
+            # Resume from a joint checkpoint
+            model = HierarchicalClaimsModel.load_from_checkpoint(ckpt, config=config)
+            freeze_non_diffusion(model)
+        else:
+            vocab_size = (
+                config.cpt_vocab_size + config.icd_vocab_size + config.ttnc_vocab_size + 3
+            )
+            diffusion = ClaimD3PM.load_from_checkpoint(
+                ckpt,
+                config=config,
+                vocab_size=vocab_size,
+                condition_dim=config.output_dim,
+            )
+            model = HierarchicalClaimsModel(config=config, diffusion=diffusion)
+            freeze_jepa(model)
+
+        model.log(
+            "jepa_frozen",
+            int(
+                all(
+                    not p.requires_grad
+                    for n, p in model.named_parameters()
+                    if not n.startswith("diffusion_model")
+                )
+            ),
+        )
+        model.log("diffusion_frozen", 0)
+
+        optim = torch.optim.AdamW(
+            filter(lambda p: p.requires_grad, model.parameters()),
+            lr=config.lr * args.lr_backbone_mult,
         )
         trainer = pl.Trainer(
             max_epochs=config.epochs,
@@ -86,7 +111,7 @@ def main(argv=None):
             callbacks=[RichProgressBar(refresh_rate=1)],
             log_every_n_steps=3,
         )
-        trainer.fit(diffusion_model, train_dataloader)
+        trainer.fit(model, train_dataloader, optimizers=optim)
         trainer.save_checkpoint("after_phase_A.ckpt")
         return
 

--- a/tests/test_load_diffusion_from_joint.py
+++ b/tests/test_load_diffusion_from_joint.py
@@ -1,0 +1,44 @@
+import os
+import tempfile
+import torch
+import unittest
+
+from jepa_utils.config import Config
+from jepa_models.hierarchical_model import HierarchicalClaimsModel
+from jepa_utils.checkpoint_utils import checkpoint_has_prefixed_keys, freeze_non_diffusion
+
+
+class TestLoadDiffusionFromJoint(unittest.TestCase):
+    def test_freeze_non_diffusion_from_joint_ckpt(self):
+        cfg = Config()
+        cfg.cpt_vocab_size = 3
+        cfg.icd_vocab_size = 3
+        cfg.ttnc_vocab_size = 2
+        cfg.cpt_rarity_scores = None
+        cfg.icd_rarity_scores = None
+        cfg.ttnc_rarity_scores = None
+        cfg.use_diffusion = True
+
+        model = HierarchicalClaimsModel(cfg)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "joint.ckpt")
+            torch.save(
+                {
+                    "state_dict": model.state_dict(),
+                    "hyper_parameters": {"config": {}},
+                    "pytorch-lightning_version": "2.2.0",
+                },
+                path,
+            )
+
+            self.assertTrue(checkpoint_has_prefixed_keys(path))
+
+            loaded = HierarchicalClaimsModel.load_from_checkpoint(path, config=cfg)
+            freeze_non_diffusion(loaded)
+            for name, param in loaded.named_parameters():
+                if not name.startswith("diffusion_model"):
+                    self.assertFalse(param.requires_grad)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add helper functions `checkpoint_has_prefixed_keys`, `freeze_non_diffusion`, and `freeze_jepa`
- load joint checkpoints when `--phase diffusion_only_finetune`
- log freeze status for JEPA and diffusion modules
- test loading diffusion weights from a joint checkpoint
- document new behaviour in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683e568dd948832c92f0e8b7b25b8547