### PR TITLE
Implement stage freezing helpers

### DIFF
--- a/jepa_utils/__init__.py
+++ b/jepa_utils/__init__.py
@@ -1,4 +1,3 @@
-from .checkpoint_utils import checkpoint_has_prefixed_keys, freeze_non_diffusion
-
-from .checkpoint_utils import freeze_jepa
+from .checkpoint_utils import checkpoint_has_prefixed_keys
+from .freezing import freeze_non_diffusion, freeze_jepa
 

--- a/jepa_utils/checkpoint_utils.py
+++ b/jepa_utils/checkpoint_utils.py
@@ -1,4 +1,5 @@
 import torch
+from .freezing import freeze_non_diffusion, freeze_jepa
 
 
 def checkpoint_has_prefixed_keys(path: str) -> bool:
@@ -6,17 +7,3 @@ def checkpoint_has_prefixed_keys(path: str) -> bool:
     ckpt = torch.load(path, map_location="cpu", weights_only=True)
     state_dict = ckpt.get("state_dict", ckpt)
     return any(k.startswith("diffusion_model.") for k in state_dict.keys())
-
-
-def freeze_non_diffusion(model):
-    """Freeze all parameters except those belonging to the diffusion model."""
-    for name, param in model.named_parameters():
-        if not name.startswith("diffusion_model"):
-            param.requires_grad = False
-
-def freeze_jepa(model):
-    """Freeze JEPA parameters (everything except diffusion)."""
-    for name, param in model.named_parameters():
-        if name.startswith("diffusion_model"):
-            continue
-        param.requires_grad = False

--- a/jepa_utils/freezing.py
+++ b/jepa_utils/freezing.py
@@ -1,0 +1,17 @@
+def freeze_non_diffusion(model, *, train_bn=False):
+    for n, p in model.named_parameters():
+        p.requires_grad = n.startswith(("diffusion.", "diffusion_model."))
+    if not train_bn:
+        for m in model.modules():
+            if m.__class__.__name__.startswith("BatchNorm"):
+                m.eval()
+
+
+def freeze_jepa(model, *, train_bn=False):
+    for n, p in model.named_parameters():
+        p.requires_grad = not n.startswith(("diffusion.", "diffusion_model."))
+    if not train_bn:
+        for m in model.modules():
+            if m.__class__.__name__.startswith("BatchNorm"):
+                m.eval()
+

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -18,7 +18,8 @@ from jepa_utils.tensor_utils import calculate_entropy, adaptive_sampling
 from jepa_utils.metrics import calculate_rmse
 from jepa_utils.config import Config
 from jepa_utils.prediction_utils import decode_predicted_codes
-from jepa_utils import checkpoint_has_prefixed_keys, freeze_non_diffusion, freeze_jepa
+from jepa_utils import checkpoint_has_prefixed_keys
+from jepa_utils.freezing import freeze_non_diffusion, freeze_jepa
 import copy
 
 
@@ -35,6 +36,7 @@ def main(argv=None):
     parser.add_argument("--freeze_diffusion", action="store_true")
     parser.add_argument("--freeze_jepa", action="store_true")
     parser.add_argument("--lr_backbone_mult", type=float, default=1.0)
+    parser.add_argument("--disable_early_stop", action="store_true")
     args = parser.parse_args(argv)
 
     if args.freeze_diffusion and args.freeze_jepa:
@@ -72,9 +74,7 @@ def main(argv=None):
             raise FileNotFoundError(f"Checkpoint {ckpt} not found")
 
         if checkpoint_has_prefixed_keys(ckpt):
-            # Resume from a joint checkpoint
             model = HierarchicalClaimsModel.load_from_checkpoint(ckpt, config=config)
-            freeze_non_diffusion(model)
         else:
             vocab_size = (
                 config.cpt_vocab_size + config.icd_vocab_size + config.ttnc_vocab_size + 3
@@ -86,32 +86,44 @@ def main(argv=None):
                 condition_dim=config.output_dim,
             )
             model = HierarchicalClaimsModel(config=config, diffusion=diffusion)
-            freeze_jepa(model)
 
-        model.log(
-            "jepa_frozen",
-            int(
-                all(
-                    not p.requires_grad
-                    for n, p in model.named_parameters()
-                    if not n.startswith("diffusion_model")
+        freeze_jepa(model)
+        model.freeze_jepa = True
+        model.freeze_diffusion = False
+
+        trainable = [n for n, p in model.named_parameters() if p.requires_grad]
+        print(f"{len(trainable)} trainable tensors:")
+        print("\n  ".join(trainable[:10]))
+
+        def _cfg_optim(self):
+            lr = config.lr * args.lr_backbone_mult
+            return torch.optim.AdamW(
+                (p for p in self.parameters() if p.requires_grad),
+                lr=lr,
+                weight_decay=config.weight_decay,
+            )
+
+        model.configure_optimizers = _cfg_optim.__get__(model)
+
+        callbacks = [RichProgressBar(refresh_rate=1)]
+        if not args.disable_early_stop:
+            callbacks.append(
+                pl.callbacks.EarlyStopping(
+                    monitor="diff_ppl_improve_10",
+                    mode="max",
+                    patience=2,
+                    min_delta=0.0,
                 )
-            ),
-        )
-        model.log("diffusion_frozen", 0)
+            )
 
-        optim = torch.optim.AdamW(
-            filter(lambda p: p.requires_grad, model.parameters()),
-            lr=config.lr * args.lr_backbone_mult,
-        )
         trainer = pl.Trainer(
             max_epochs=config.epochs,
             accelerator="gpu",
             logger=pl.loggers.TensorBoardLogger("tb_logs", name="phase_a"),
-            callbacks=[RichProgressBar(refresh_rate=1)],
+            callbacks=callbacks,
             log_every_n_steps=3,
         )
-        trainer.fit(model, train_dataloader, optimizers=optim)
+        trainer.fit(model, train_dataloader)
         trainer.save_checkpoint("after_phase_A.ckpt")
         return
 
@@ -146,7 +158,6 @@ def main(argv=None):
         return
 
     if args.phase == "jepa_only":
-        config.freeze_diffusion = True
         ckpt = args.resume or "after_phase_A.ckpt"
         if not os.path.exists(ckpt):
             raise FileNotFoundError(f"Checkpoint {ckpt} not found")
@@ -163,11 +174,41 @@ def main(argv=None):
             condition_dim=config.output_dim,
         )
         model = HierarchicalClaimsModel(config, diffusion=diffusion_model)
+
+        freeze_non_diffusion(model)
+        model.freeze_diffusion = True
+        model.freeze_jepa = False
+
+        trainable = [n for n, p in model.named_parameters() if p.requires_grad]
+        print(f"{len(trainable)} trainable tensors:")
+        print("\n  ".join(trainable[:10]))
+
+        def _cfg_optim(self):
+            lr = config.lr * args.lr_backbone_mult
+            return torch.optim.AdamW(
+                (p for p in self.parameters() if p.requires_grad),
+                lr=lr,
+                weight_decay=config.weight_decay,
+            )
+
+        model.configure_optimizers = _cfg_optim.__get__(model)
+
+        callbacks = [RichProgressBar(refresh_rate=1)]
+        if not args.disable_early_stop:
+            callbacks.append(
+                pl.callbacks.EarlyStopping(
+                    monitor="diff_ppl_improve_10",
+                    mode="max",
+                    patience=2,
+                    min_delta=0.0,
+                )
+            )
+
         trainer = pl.Trainer(
             max_epochs=config.epochs,
             accelerator="gpu",
             logger=pl.loggers.TensorBoardLogger("tb_logs", name="phase_b"),
-            callbacks=[RichProgressBar(refresh_rate=1), RichModelSummary(max_depth=2)],
+            callbacks=callbacks,
             log_every_n_steps=3,
         )
         trainer.fit(model, train_dataloader)


### PR DESCRIPTION
## Summary
- add new `freeze_non_diffusion` and `freeze_jepa` helpers
- re-export helpers in `jepa_utils.__init__`
- adjust checkpoint utils to import new helpers
- extend training script with stage-aware freezing and early-stop toggling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683ee33c9ed4832ca5bd0b4d955356b1