### PR TITLE
Fix diffusion freeze logic and early-stop config

### DIFF
--- a/diffusion_models/claim_d3pm.py
+++ b/diffusion_models/claim_d3pm.py
@@ -18,6 +18,7 @@ class ClaimD3PM(pl.LightningModule):
         self.teacher_forcing_epochs = getattr(config, "teacher_forcing_epochs", 0)
         self.label_smoothing = getattr(config, "diffusion_label_smoothing", 0.0)
         self.kickstart_lr_scale = getattr(config, "lr_backbone_mult", getattr(config, "kickstart_lr_scale", 1.0))
+        self.disable_early_stop = getattr(config, "disable_early_stop", False)
 
         # Transition noise schedule (flatten-to-uniform). ``alphas`` controls
         # the probability of replacing a token with uniform noise at each time
@@ -192,6 +193,6 @@ class ClaimD3PM(pl.LightningModule):
             if len(self.ppl_history) >= 10:
                 improve = self.ppl_history[-10] / current_ppl
                 self.log("diff_ppl_improve_10", improve, prog_bar=True, logger=True)
-                if improve < 1.03 and self.trainer is not None:
+                if improve < 1.03 and self.trainer is not None and not self.disable_early_stop:
                     self.trainer.should_stop = True
         self.epoch_losses = []

--- a/jepa_models/hierarchical_model.py
+++ b/jepa_models/hierarchical_model.py
@@ -205,6 +205,7 @@ class HierarchicalClaimsModel(pl.LightningModule):
         self.freeze_diffusion = getattr(config, 'freeze_diffusion', False)
         self.freeze_jepa = getattr(config, 'freeze_jepa', False)
         self.lr_backbone_mult = getattr(config, 'lr_backbone_mult', 1.0)
+        self.disable_early_stop = getattr(config, 'disable_early_stop', False)
 
         self.cpt_base_threshold = getattr(config, 'base_cpt_threshold', getattr(config, 'cpt_threshold', 0.5))
         self.icd_base_threshold = getattr(config, 'base_icd_threshold', getattr(config, 'icd_threshold', 0.5))
@@ -1206,7 +1207,7 @@ class HierarchicalClaimsModel(pl.LightningModule):
                 prev_avg = sum(self.diff_ppl_history[-window:]) / window
                 diff_ppl_improve = prev_avg / avg_ppl
                 self.log("diff_ppl_improve_10", diff_ppl_improve, prog_bar=True, logger=True)
-                if diff_ppl_improve < 1.03 and hasattr(self, "trainer"):
+                if diff_ppl_improve < 1.03 and hasattr(self, "trainer") and not self.disable_early_stop:
                     self.trainer.should_stop = True
             self.diff_ppl_history.append(avg_ppl)
             self.diff_ppl_total = 0.0

--- a/jepa_utils/config.py
+++ b/jepa_utils/config.py
@@ -24,6 +24,7 @@ class Config:
     adapter_lr: float = 1e-4    # LR for encoder adapter layers during Stage 2
     generator_lr: float = 5e-4  # LR for generator modules during Stage 2
     epochs: int = 25
+    weight_decay: float = 0.0
     ema_decay: float = 0.999    # Higher value = less lagged updates to target encoder (use < 1)
     epsilon: float = 1e-4  
     var_penalty_scale_lvl1: float = 1.0
@@ -67,6 +68,7 @@ class Config:
     freeze_diffusion: bool = False
     freeze_jepa: bool = False
     lr_backbone_mult: float = 1.0
+    disable_early_stop: bool = False
     # Kickstart plan hyperparameters
     teacher_forcing_epochs: int = 0
     diffusion_label_smoothing: float = 0.0

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -47,6 +47,7 @@ def main(argv=None):
     config.freeze_diffusion = args.freeze_diffusion
     config.freeze_jepa = args.freeze_jepa
     config.lr_backbone_mult = args.lr_backbone_mult
+    config.disable_early_stop = args.disable_early_stop
 
     print('Preparing Data')
     train_dataset, train_dataloader, eval_dataset, eval_dataloader, config, dataset = prepare_data(config)
@@ -87,7 +88,7 @@ def main(argv=None):
             )
             model = HierarchicalClaimsModel(config=config, diffusion=diffusion)
 
-        freeze_jepa(model)
+        freeze_non_diffusion(model)
         model.freeze_jepa = True
         model.freeze_diffusion = False
 
@@ -106,7 +107,7 @@ def main(argv=None):
         model.configure_optimizers = _cfg_optim.__get__(model)
 
         callbacks = [RichProgressBar(refresh_rate=1)]
-        if not args.disable_early_stop:
+        if not config.disable_early_stop:
             callbacks.append(
                 pl.callbacks.EarlyStopping(
                     monitor="diff_ppl_improve_10",
@@ -175,7 +176,7 @@ def main(argv=None):
         )
         model = HierarchicalClaimsModel(config, diffusion=diffusion_model)
 
-        freeze_non_diffusion(model)
+        freeze_jepa(model)
         model.freeze_diffusion = True
         model.freeze_jepa = False
 
@@ -194,7 +195,7 @@ def main(argv=None):
         model.configure_optimizers = _cfg_optim.__get__(model)
 
         callbacks = [RichProgressBar(refresh_rate=1)]
-        if not args.disable_early_stop:
+        if not config.disable_early_stop:
             callbacks.append(
                 pl.callbacks.EarlyStopping(
                     monitor="diff_ppl_improve_10",


### PR DESCRIPTION
## Summary
- add `weight_decay` and `disable_early_stop` fields to `Config`
- freeze the correct modules when resuming diffusion-only or JEPA-only phases
- respect `disable_early_stop` inside diffusion and hierarchical models
- pass the flag through `train.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683eefb3f3e0832c95c7fac5269a41d4